### PR TITLE
Turn off client validation on kubectl apply

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -151,7 +151,7 @@ func isCompatible(clientMajor, clientMinor, serverMajor, serverMinor string) err
 // Apply attempts to "kubectl apply" the file located at path.
 // It returns the full apply command and its output.
 func (c *Client) Apply(path, namespace string, dryRun bool) (string, string, error) {
-	args := []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%t", dryRun), "-R", "-f", path, "--prune", fmt.Sprintf("-l %s!=%s", c.Label, Off), "-n", namespace}
+	args := []string{"kubectl", "apply", "--validate=false", fmt.Sprintf("--dry-run=%t", dryRun), "-R", "-f", path, "--prune", fmt.Sprintf("-l %s!=%s", c.Label, Off), "-n", namespace}
 	for _, w := range pruneWhitelist {
 		args = append(args, "--prune-whitelist="+w)
 	}


### PR DESCRIPTION
Currently we have encrypted manifests being applied by the client. As
they are not valid yaml, apply panics and stops the run. We should
support both decrypted resources and skip over unparsable manifests.

This change turns off validation on the client only so instead of panic
client skips over invalid yaml files with error:

```
unable to decode "secrets/dockerhub-key.yaml": json: cannot unmarshal
string into Go value of type unstructured.detector
```