### PR TITLE
Track cases where kubectl exits because of a signal

### DIFF
--- a/kube/client_test.go
+++ b/kube/client_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/utilitywarehouse/kube-applier/metrics"
 )
 
 var testServiceAccount = false
@@ -67,7 +70,17 @@ func TestGetNamespaceUserSecretName(t *testing.T) {
 	testServiceAccount = true
 	defer func() { testServiceAccount = false }()
 
-	testClient := &Client{}
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	metrics := metrics.NewMockPrometheusInterface(mockCtrl)
+
+	testClient := &Client{
+		Metrics: metrics,
+	}
+
+	metrics.EXPECT().UpdateKubectlExitCodeCount("namespace", 0).Times(1)
+
 	secret, err := testClient.GetNamespaceUserSecretName("namespace", "username")
 	if err != nil {
 		t.Fatal(err)
@@ -85,7 +98,17 @@ func TestGetUserDataFromSecret(t *testing.T) {
 	testSecret = true
 	defer func() { testSecret = false }()
 
-	testClient := &Client{}
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	metrics := metrics.NewMockPrometheusInterface(mockCtrl)
+
+	testClient := &Client{
+		Metrics: metrics,
+	}
+
+	metrics.EXPECT().UpdateKubectlExitCodeCount("namespace", 0).Times(1)
+
 	token, cert, err := testClient.GetUserDataFromSecret("namespace", "secretname")
 	if err != nil {
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -141,7 +141,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	kubeClient := &kube.Client{Server: server, Label: label}
+	kubeClient := &kube.Client{
+		Server:  server,
+		Label:   label,
+		Metrics: metrics,
+	}
 
 	if err := kubeClient.Configure(); err != nil {
 		log.Logger.Error("kubectl configuration failed", "error", err)

--- a/metrics/mock_prometheus.go
+++ b/metrics/mock_prometheus.go
@@ -32,16 +32,16 @@ func (m *MockPrometheusInterface) EXPECT() *MockPrometheusInterfaceMockRecorder 
 	return m.recorder
 }
 
-// UpdateKubectlSignalExitCount mocks base method
-func (m *MockPrometheusInterface) UpdateKubectlSignalExitCount(arg0 string) {
+// UpdateKubectlExitCodeCount mocks base method
+func (m *MockPrometheusInterface) UpdateKubectlExitCodeCount(arg0 string, arg1 int) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateKubectlSignalExitCount", arg0)
+	m.ctrl.Call(m, "UpdateKubectlExitCodeCount", arg0, arg1)
 }
 
-// UpdateKubectlSignalExitCount indicates an expected call of UpdateKubectlSignalExitCount
-func (mr *MockPrometheusInterfaceMockRecorder) UpdateKubectlSignalExitCount(arg0 interface{}) *gomock.Call {
+// UpdateKubectlExitCodeCount indicates an expected call of UpdateKubectlExitCodeCount
+func (mr *MockPrometheusInterfaceMockRecorder) UpdateKubectlExitCodeCount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubectlSignalExitCount", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateKubectlSignalExitCount), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubectlExitCodeCount", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateKubectlExitCodeCount), arg0, arg1)
 }
 
 // UpdateNamespaceSuccess mocks base method

--- a/metrics/mock_prometheus.go
+++ b/metrics/mock_prometheus.go
@@ -32,32 +32,50 @@ func (m *MockPrometheusInterface) EXPECT() *MockPrometheusInterfaceMockRecorder 
 	return m.recorder
 }
 
+// UpdateKubectlSignalExitCount mocks base method
+func (m *MockPrometheusInterface) UpdateKubectlSignalExitCount(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateKubectlSignalExitCount", arg0)
+}
+
+// UpdateKubectlSignalExitCount indicates an expected call of UpdateKubectlSignalExitCount
+func (mr *MockPrometheusInterfaceMockRecorder) UpdateKubectlSignalExitCount(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubectlSignalExitCount", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateKubectlSignalExitCount), arg0)
+}
+
 // UpdateNamespaceSuccess mocks base method
 func (m *MockPrometheusInterface) UpdateNamespaceSuccess(arg0 string, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateNamespaceSuccess", arg0, arg1)
 }
 
 // UpdateNamespaceSuccess indicates an expected call of UpdateNamespaceSuccess
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateNamespaceSuccess(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespaceSuccess", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateNamespaceSuccess), arg0, arg1)
 }
 
 // UpdateRunLatency mocks base method
 func (m *MockPrometheusInterface) UpdateRunLatency(arg0 float64, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateRunLatency", arg0, arg1)
 }
 
 // UpdateRunLatency indicates an expected call of UpdateRunLatency
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateRunLatency(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRunLatency", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateRunLatency), arg0, arg1)
 }
 
 // UpdateResultSummary mocks base method
 func (m *MockPrometheusInterface) UpdateResultSummary(arg0 map[string]string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateResultSummary", arg0)
 }
 
 // UpdateResultSummary indicates an expected call of UpdateResultSummary
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateResultSummary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResultSummary", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateResultSummary), arg0)
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -81,7 +81,7 @@ func (p *Prometheus) Init() {
 	prometheus.MustRegister(p.runLatency)
 }
 
-// UpdateKubectlExitCodeCount increments the given namespace's Counter when the process is terminated by a signal
+// UpdateKubectlExitCodeCount increments for each exit code returned by kubectl
 func (p *Prometheus) UpdateKubectlExitCodeCount(file string, code int) {
 	p.kubectlExitCodeCount.With(prometheus.Labels{
 		"namespace": filepath.Base(file),

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -1,10 +1,8 @@
 package run
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/utilitywarehouse/kube-applier/kube"
@@ -44,17 +42,8 @@ func (a *BatchApplier) Apply(applyList []string) ([]ApplyAttempt, []ApplyAttempt
 		ns := filepath.Base(path)
 		s, err := a.KubeClient.GetNamespaceStatus(ns)
 		if err != nil {
-			var namespaceStatusError error
-			if e, ok := err.(*exec.ExitError); ok && e.ExitCode() == -1 {
-				a.Metrics.UpdateKubectlSignalExitCount(path)
-				namespaceStatusError = errors.New(err.Error() + " - this may have been caused by the Out Of Memory killer, please investigate")
-
-			} else {
-				namespaceStatusError = err
-			}
-			log.Logger.Error("Error while getting namespace status, defaulting to off", "error", namespaceStatusError)
+			log.Logger.Error("Error while getting namespace status, defaulting to off", "error", err)
 		}
-
 		var disabled bool
 		switch s {
 		case kube.On:
@@ -84,12 +73,7 @@ func (a *BatchApplier) Apply(applyList []string) ([]ApplyAttempt, []ApplyAttempt
 			successes = append(successes, appliedFile)
 			log.Logger.Info(fmt.Sprintf("%v\n%v", cmd, output))
 		} else {
-			if e, ok := err.(*exec.ExitError); ok && e.ExitCode() == -1 {
-				appliedFile.ErrorMessage = err.Error() + " - this may have been caused by the Out Of Memory killer, please investigate"
-				a.Metrics.UpdateKubectlSignalExitCount(path)
-			} else {
-				appliedFile.ErrorMessage = err.Error()
-			}
+			appliedFile.ErrorMessage = err.Error()
 			failures = append(failures, appliedFile)
 			log.Logger.Warn(fmt.Sprintf("%v\n%v\n%v", cmd, output, appliedFile.ErrorMessage))
 		}


### PR DESCRIPTION
Increment a metric every time kubectl returns an exit code of "-1" (process killed prematurely by a signal, or some other unknown).

Also add a bit more context to the error message we log.

This will help us to identify cases where kubectl is killed by the OOM killer.