### PR TITLE
Support shell file name patterns in REPO_PATH_FILTERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kube-applier serves a [status page](#status-ui) and provides [metrics](#metrics)
 * `LISTEN_PORT` - (int) Port for the container. This should be the same port specified in the container spec.
 
 **Optional:**
-* `REPO_PATH_FILTERS` - (string) A comma separated list of sub directories to be applied.
+* `REPO_PATH_FILTERS` - (string) A comma separated list of sub directories to be applied. Supports [shell file name patterns](https://golang.org/pkg/path/filepath/#Match).
 * `SERVER` - (string) Address of the Kubernetes API server. By default, discovery of the API server is handled by kube-proxy. If kube-proxy is not set up, the API server address must be specified with this environment variable (which is then written into a [kubeconfig file](http://kubernetes.io/docs/user-guide/kubeconfig-file/) on the backend). Authentication to the API server is handled by service account tokens. See [Accessing the Cluster](http://kubernetes.io/docs/user-guide/accessing-the-cluster/#accessing-the-api-from-a-pod) for more info.
 * `POLL_INTERVAL_SECONDS` - (int) Number of seconds to wait between each check for new commits to the repo (default is 5).
 * <a name="run-interval"></a>`FULL_RUN_INTERVAL_SECONDS` - (int) Number of seconds between automatic full runs (default is 300, or 5 minutes). Set to 0 to disable.

--- a/run/runner.go
+++ b/run/runner.go
@@ -2,11 +2,13 @@ package run
 
 import (
 	"fmt"
+	"path"
+	"path/filepath"
+
 	"github.com/utilitywarehouse/kube-applier/git"
 	"github.com/utilitywarehouse/kube-applier/log"
 	"github.com/utilitywarehouse/kube-applier/metrics"
 	"github.com/utilitywarehouse/kube-applier/sysutil"
-	"path"
 )
 
 // Runner manages the full process of an apply run, including getting the appropriate files, running apply commands on them, and handling the results.
@@ -86,7 +88,10 @@ func (r *Runner) pruneDirs(dirs []string) []string {
 	var prunedDirs []string
 	for _, dir := range dirs {
 		for _, repoPathFilter := range r.RepoPathFilters {
-			if dir == path.Join(r.RepoPath, repoPathFilter) {
+			matched, err := filepath.Match(path.Join(r.RepoPath, repoPathFilter), dir)
+			if err != nil {
+				log.Logger.Error(err.Error())
+			} else if matched {
 				prunedDirs = append(prunedDirs, dir)
 			}
 		}

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -1,15 +1,16 @@
 package run
 
 import (
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPruneDirsWithFilter(t *testing.T) {
 	runner := Runner{
 		RepoPath:        "/repo/",
-		RepoPathFilters: []string{"run", "webserver"},
+		RepoPathFilters: []string{"run", "webserver", "sys*", "?anifests"},
 	}
 
 	dirs := strings.Split(`/repo/.git
@@ -22,12 +23,13 @@ func TestPruneDirsWithFilter(t *testing.T) {
 /repo/run
 /repo/static
 /repo/sysutil
+/repo/sys-log
 /repo/templates
 /repo/webserver
 `, "\n")
 
 	prunedDirs := runner.pruneDirs(dirs)
-	assert.Len(t, prunedDirs, 2)
+	assert.Len(t, prunedDirs, 5)
 }
 
 func TestPruneDirsWithoutFilter(t *testing.T) {
@@ -46,10 +48,11 @@ func TestPruneDirsWithoutFilter(t *testing.T) {
 /repo/run
 /repo/static
 /repo/sysutil
+/repo/sys-log
 /repo/templates
 /repo/webserver
 `, "\n")
 
 	prunedDirs := runner.pruneDirs(dirs)
-	assert.Len(t, prunedDirs, 13)
+	assert.Len(t, prunedDirs, 14)
 }


### PR DESCRIPTION
Allows us to specify `sys-*` as a repo path filter, rather than listing them all out for the systems specific KA instance.