### PR TITLE
no-prune per namespace

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -53,9 +53,10 @@ type AutomaticDeploymentOption string
 
 // Automatic Deployment labels
 const (
-	DryRun AutomaticDeploymentOption = "dry-run"
-	On     AutomaticDeploymentOption = "on"
-	Off    AutomaticDeploymentOption = "off"
+	DryRun  AutomaticDeploymentOption = "dry-run"
+	On      AutomaticDeploymentOption = "on"
+	Off     AutomaticDeploymentOption = "off"
+	NoPrune AutomaticDeploymentOption = "on-no-prune"
 )
 
 // ClientInterface allows for mocking out the functionality of Client when testing the full process of an apply run.

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -46,13 +46,19 @@ func (a *BatchApplier) Apply(applyList []string) ([]ApplyAttempt, []ApplyAttempt
 			log.Logger.Error("Error while getting namespace status, defaulting to off", "error", err)
 		}
 		var disabled bool
+		var prune bool
 		switch s {
 		case kube.On:
 			disabled = false
+			prune = a.Prune
 		case kube.Off:
 			continue
 		case kube.DryRun:
 			disabled = true
+			prune = a.Prune
+		case kube.NoPrune:
+			disabled = false
+			prune = false
 		default:
 			continue
 		}
@@ -67,7 +73,7 @@ func (a *BatchApplier) Apply(applyList []string) ([]ApplyAttempt, []ApplyAttempt
 		}
 
 		var cmd, output string
-		cmd, output, err = a.KubeClient.Apply(path, ns, a.ServiceAccount, a.DryRun || disabled, a.Prune, kustomize)
+		cmd, output, err = a.KubeClient.Apply(path, ns, a.ServiceAccount, a.DryRun || disabled, prune, kustomize)
 		success := (err == nil)
 		appliedFile := ApplyAttempt{path, cmd, output, ""}
 		if success {


### PR DESCRIPTION
kube-applier is either all in or non at all when it comes to pruning. I needed a granularity on a namespace bases. As some namespaces may have shared ownership. This merge-request will provide that. 

Use case:
kube-applier should be able to put services and certificates in istio-system in a GKE managed istio. As GKE provide the Istio yaml, this currently won't work well if you want pruning on other namespaces.