### PR TITLE
Set full run interval at 1hr

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ kube-applier serves a [status page](#status-ui) and provides
   for new commits to the repo (default is 5).
 
 * <a name="run-interval"></a>`FULL_RUN_INTERVAL_SECONDS` - (int) Number of
-  seconds between automatic full runs (default is 300). Set to 0 to disable.
+  seconds between automatic full runs (default is 3600). Set to 0 to disable.
 
 * `DRY_RUN` - (bool) If true, kubectl command will be run with --server-dry-run
   flag. This means live configuration of the cluster is not changed.

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func validate() {
 	}
 
 	if fullRunInterval == "" {
-		fullRunInterval = "60"
+		fullRunInterval = "3600"
 	} else {
 		_, err := strconv.Atoi(fullRunInterval)
 		if err != nil {


### PR DESCRIPTION
New resources, modifications and deletions will be caught by a short
poll interval. Full run interval only prunes undefined resources, this
doesn't need to happen often and the load on the api server is not a
good trade off.