### PR TITLE
Fix the force-run button

### DIFF
--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -109,7 +109,7 @@ func (ws *WebServer) Start() {
 	forceRunHandler := &ForceRunHandler{
 		ws.RunQueue,
 	}
-	m.PathPrefix("/api/1.0/forceRun").Handler(forceRunHandler)
+	m.PathPrefix("/api/v1/forceRun").Handler(forceRunHandler)
 	m.PathPrefix("/").Handler(statusPageHandler)
 
 	go func() {


### PR DESCRIPTION
There was a mismatch between the path exposed by the webserver and the path used in the js.

I think v1 is a more common format for API versions than 1.0, so I went with that.