### PR TITLE
Use tini to avoid zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ FROM alpine:3.10
 ENV KUBECTL_VERSION v1.14.2
 COPY templates/ /templates/
 COPY static/ /static/
-RUN apk --no-cache add git openssh-client &&\
+RUN apk --no-cache add git openssh-client tini &&\
   git config --global url.ssh://git@github.com/.insteadOf https://github.com/ &&\
   wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
   chmod +x /usr/local/bin/kubectl
 COPY --from=build /kube-applier /kube-applier
+
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "/kube-applier" ]


### PR DESCRIPTION
Failed runs of `kubectl apply -k` leave 'ssh' zombie processes in their wake. This is because
kube-applier runs as PID 1 but doesn't reap zombie processes that have been re-parented to PID 1 like an init process should.

[tini](https://github.com/krallin/tini) is a tiny init process designed to mitigate this issue.