### PR TITLE
annotation metrics

### DIFF
--- a/git/mock_gitutil.go
+++ b/git/mock_gitutil.go
@@ -34,6 +34,7 @@ func (m *MockUtilInterface) EXPECT() *MockUtilInterfaceMockRecorder {
 
 // HeadCommitLogForPaths mocks base method
 func (m *MockUtilInterface) HeadCommitLogForPaths(args ...string) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range args {
 		varargs = append(varargs, a)
@@ -46,11 +47,13 @@ func (m *MockUtilInterface) HeadCommitLogForPaths(args ...string) (string, error
 
 // HeadCommitLogForPaths indicates an expected call of HeadCommitLogForPaths
 func (mr *MockUtilInterfaceMockRecorder) HeadCommitLogForPaths(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadCommitLogForPaths", reflect.TypeOf((*MockUtilInterface)(nil).HeadCommitLogForPaths), args...)
 }
 
 // HeadHashForPaths mocks base method
 func (m *MockUtilInterface) HeadHashForPaths(args ...string) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range args {
 		varargs = append(varargs, a)
@@ -63,5 +66,6 @@ func (m *MockUtilInterface) HeadHashForPaths(args ...string) (string, error) {
 
 // HeadHashForPaths indicates an expected call of HeadHashForPaths
 func (mr *MockUtilInterfaceMockRecorder) HeadHashForPaths(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadHashForPaths", reflect.TypeOf((*MockUtilInterface)(nil).HeadHashForPaths), args...)
 }

--- a/kube/mock_client.go
+++ b/kube/mock_client.go
@@ -34,6 +34,7 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 
 // Apply mocks base method
 func (m *MockClientInterface) Apply(path, namespace string, dryRun, prune, kustomize bool) (string, string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", path, namespace, dryRun, prune, kustomize)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
@@ -43,11 +44,13 @@ func (m *MockClientInterface) Apply(path, namespace string, dryRun, prune, kusto
 
 // Apply indicates an expected call of Apply
 func (mr *MockClientInterfaceMockRecorder) Apply(path, namespace, dryRun, prune, kustomize interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClientInterface)(nil).Apply), path, namespace, dryRun, prune, kustomize)
 }
 
 // NamespaceAnnotations mocks base method
 func (m *MockClientInterface) NamespaceAnnotations(namespace string) (KAAnnotations, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NamespaceAnnotations", namespace)
 	ret0, _ := ret[0].(KAAnnotations)
 	ret1, _ := ret[1].(error)
@@ -56,5 +59,21 @@ func (m *MockClientInterface) NamespaceAnnotations(namespace string) (KAAnnotati
 
 // NamespaceAnnotations indicates an expected call of NamespaceAnnotations
 func (mr *MockClientInterfaceMockRecorder) NamespaceAnnotations(namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceAnnotations", reflect.TypeOf((*MockClientInterface)(nil).NamespaceAnnotations), namespace)
+}
+
+// NamespaceAnnotationsBatch mocks base method
+func (m *MockClientInterface) NamespaceAnnotationsBatch(namespaces []string) (map[string]KAAnnotations, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NamespaceAnnotationsBatch", namespaces)
+	ret0, _ := ret[0].(map[string]KAAnnotations)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NamespaceAnnotationsBatch indicates an expected call of NamespaceAnnotationsBatch
+func (mr *MockClientInterfaceMockRecorder) NamespaceAnnotationsBatch(namespaces interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NamespaceAnnotationsBatch", reflect.TypeOf((*MockClientInterface)(nil).NamespaceAnnotationsBatch), namespaces)
 }

--- a/main.go
+++ b/main.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/utilitywarehouse/kube-applier/git"
 	"github.com/utilitywarehouse/kube-applier/kube"
 	"github.com/utilitywarehouse/kube-applier/log"
 	"github.com/utilitywarehouse/kube-applier/metrics"
+	"github.com/utilitywarehouse/kube-applier/metrics/annotations"
 	"github.com/utilitywarehouse/kube-applier/run"
 	"github.com/utilitywarehouse/kube-applier/sysutil"
 	"github.com/utilitywarehouse/kube-applier/webserver"
@@ -159,6 +161,12 @@ func main() {
 		RunResults:      runResults,
 		Errors:          errors,
 	}
+
+	prometheus.MustRegister(&annotations.Collector{
+		RepoPath:        repoPath,
+		RepoPathFilters: repoPathFiltersSlice,
+		KubeClient:      kubeClient,
+	})
 
 	pi, _ := strconv.Atoi(pollInterval)
 	fi, _ := strconv.Atoi(fullRunInterval)

--- a/metrics/annotations/collector.go
+++ b/metrics/annotations/collector.go
@@ -1,0 +1,125 @@
+package annotations
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/utilitywarehouse/kube-applier/kube"
+	"github.com/utilitywarehouse/kube-applier/log"
+	"github.com/utilitywarehouse/kube-applier/sysutil"
+)
+
+var (
+	enabledDesc = prometheus.NewDesc(
+		"kube_applier_enabled",
+		"Is kube-applier enabled?",
+		[]string{"namespace"}, nil,
+	)
+	dryRunDesc = prometheus.NewDesc(
+		"kube_applier_dry_run",
+		"Is kube-applier set to dry-run?",
+		[]string{"namespace"}, nil,
+	)
+	pruneDesc = prometheus.NewDesc(
+		"kube_applier_prune",
+		"Is kube-applier configured to prune resources?",
+		[]string{"namespace"}, nil,
+	)
+	successDesc = prometheus.NewDesc(
+		"kube_applier_annotations_get_success",
+		"Were the annotations retrieved successfully?",
+		[]string{}, nil,
+	)
+)
+
+// Collector exports kube applier configuration annotations as Prometheus metrics
+type Collector struct {
+	RepoPath        string
+	RepoPathFilters []string
+	KubeClient      *kube.Client
+}
+
+// Describe describes the metrics exported by Collector
+func (c Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- enabledDesc
+	ch <- dryRunDesc
+	ch <- pruneDesc
+	ch <- successDesc
+}
+
+// Collect retrieves the annotations from kube for the relevant namespaces and creates metrics from them
+func (c Collector) Collect(ch chan<- prometheus.Metric) {
+	dirs, err := sysutil.ListDirs(c.RepoPath)
+	if err != nil {
+		return
+	}
+	dirs = sysutil.PruneDirs(dirs, c.RepoPathFilters)
+
+	var namespaces []string
+	for _, dir := range dirs {
+		namespaces = append(namespaces, filepath.Base(dir))
+	}
+
+	kaaMap, err := c.KubeClient.NamespaceAnnotationsBatch(namespaces)
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			log.Logger.Error("Error when retrieving namespaces from kube", "error", err, "stderr", string(e.Stderr))
+		} else {
+			log.Logger.Error("Error when retrieving namespaces from kube", "error", err)
+		}
+		ch <- prometheus.MustNewConstMetric(
+			successDesc,
+			prometheus.GaugeValue,
+			float64(0),
+		)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(
+		successDesc,
+		prometheus.GaugeValue,
+		float64(1),
+	)
+
+	for namespace, annotations := range kaaMap {
+		enabled, err := strconv.ParseBool(annotations.Enabled)
+		if err == nil {
+			ch <- prometheus.MustNewConstMetric(
+				enabledDesc,
+				prometheus.GaugeValue,
+				boolFloat64(enabled),
+				namespace,
+			)
+		}
+
+		dryRun, err := strconv.ParseBool(annotations.DryRun)
+		if err == nil {
+			ch <- prometheus.MustNewConstMetric(
+				dryRunDesc,
+				prometheus.GaugeValue,
+				boolFloat64(dryRun),
+				namespace,
+			)
+		}
+
+		prune, err := strconv.ParseBool(annotations.Prune)
+		if err == nil {
+			ch <- prometheus.MustNewConstMetric(
+				pruneDesc,
+				prometheus.GaugeValue,
+				boolFloat64(prune),
+				namespace,
+			)
+		}
+	}
+}
+
+// boolFloat64 converts a bool to a float64, as expected by Prometheus
+// 0=false, 1=true
+func boolFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/metrics/annotations/collector_test.go
+++ b/metrics/annotations/collector_test.go
@@ -1,0 +1,19 @@
+package annotations
+
+import "testing"
+
+func TestBoolFloat64True(t *testing.T) {
+	f := boolFloat64(true)
+
+	if f != float64(1) {
+		t.Errorf("Conversion of true was incorrect, got %g, want: %g", f, float64(1))
+	}
+}
+
+func TestBoolFloat64False(t *testing.T) {
+	f := boolFloat64(false)
+
+	if f != float64(0) {
+		t.Errorf("Conversion of false was incorrect, got %g, want: %g", f, float64(0))
+	}
+}

--- a/metrics/mock_prometheus.go
+++ b/metrics/mock_prometheus.go
@@ -34,40 +34,48 @@ func (m *MockPrometheusInterface) EXPECT() *MockPrometheusInterfaceMockRecorder 
 
 // UpdateKubectlExitCodeCount mocks base method
 func (m *MockPrometheusInterface) UpdateKubectlExitCodeCount(arg0 string, arg1 int) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateKubectlExitCodeCount", arg0, arg1)
 }
 
 // UpdateKubectlExitCodeCount indicates an expected call of UpdateKubectlExitCodeCount
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateKubectlExitCodeCount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubectlExitCodeCount", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateKubectlExitCodeCount), arg0, arg1)
 }
 
 // UpdateNamespaceSuccess mocks base method
 func (m *MockPrometheusInterface) UpdateNamespaceSuccess(arg0 string, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateNamespaceSuccess", arg0, arg1)
 }
 
 // UpdateNamespaceSuccess indicates an expected call of UpdateNamespaceSuccess
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateNamespaceSuccess(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespaceSuccess", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateNamespaceSuccess), arg0, arg1)
 }
 
 // UpdateRunLatency mocks base method
 func (m *MockPrometheusInterface) UpdateRunLatency(arg0 float64, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateRunLatency", arg0, arg1)
 }
 
 // UpdateRunLatency indicates an expected call of UpdateRunLatency
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateRunLatency(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRunLatency", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateRunLatency), arg0, arg1)
 }
 
 // UpdateResultSummary mocks base method
 func (m *MockPrometheusInterface) UpdateResultSummary(arg0 map[string]string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateResultSummary", arg0)
 }
 
 // UpdateResultSummary indicates an expected call of UpdateResultSummary
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateResultSummary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResultSummary", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateResultSummary), arg0)
 }

--- a/run/runner.go
+++ b/run/runner.go
@@ -2,8 +2,6 @@ package run
 
 import (
 	"fmt"
-	"path"
-	"path/filepath"
 
 	"github.com/utilitywarehouse/kube-applier/git"
 	"github.com/utilitywarehouse/kube-applier/log"
@@ -48,7 +46,7 @@ func (r *Runner) run() (*Result, error) {
 		return nil, err
 	}
 
-	dirs = r.pruneDirs(dirs)
+	dirs = sysutil.PruneDirs(dirs, r.RepoPathFilters)
 
 	hash, err := r.GitUtil.HeadHashForPaths(r.RepoPathFilters...)
 	if err != nil {
@@ -78,24 +76,4 @@ func (r *Runner) run() (*Result, error) {
 
 	newRun := Result{start, finish, hash, commitLog, successes, failures, r.DiffURLFormat}
 	return &newRun, nil
-}
-
-func (r *Runner) pruneDirs(dirs []string) []string {
-	if len(r.RepoPathFilters) == 0 {
-		return dirs
-	}
-
-	var prunedDirs []string
-	for _, dir := range dirs {
-		for _, repoPathFilter := range r.RepoPathFilters {
-			matched, err := filepath.Match(path.Join(r.RepoPath, repoPathFilter), dir)
-			if err != nil {
-				log.Logger.Error(err.Error())
-			} else if matched {
-				prunedDirs = append(prunedDirs, dir)
-			}
-		}
-	}
-
-	return prunedDirs
 }

--- a/sysutil/filesystem_test.go
+++ b/sysutil/filesystem_test.go
@@ -1,4 +1,4 @@
-package run
+package sysutil
 
 import (
 	"strings"
@@ -8,11 +8,7 @@ import (
 )
 
 func TestPruneDirsWithFilter(t *testing.T) {
-	runner := Runner{
-		RepoPath:        "/repo/",
-		RepoPathFilters: []string{"run", "webserver", "sys*", "?anifests"},
-	}
-
+	filters := []string{"run", "webserver", "sys*", "?anifests"}
 	dirs := strings.Split(`/repo/.git
 /repo/git
 /repo/kube
@@ -28,16 +24,12 @@ func TestPruneDirsWithFilter(t *testing.T) {
 /repo/webserver
 `, "\n")
 
-	prunedDirs := runner.pruneDirs(dirs)
+	prunedDirs := PruneDirs(dirs, filters)
 	assert.Len(t, prunedDirs, 5)
 }
 
 func TestPruneDirsWithoutFilter(t *testing.T) {
-	runner := Runner{
-		RepoPath:        "/repo/",
-		RepoPathFilters: []string{},
-	}
-
+	filters := []string{}
 	dirs := strings.Split(`/repo/.git
 /repo/git
 /repo/kube
@@ -53,6 +45,6 @@ func TestPruneDirsWithoutFilter(t *testing.T) {
 /repo/webserver
 `, "\n")
 
-	prunedDirs := runner.pruneDirs(dirs)
+	prunedDirs := PruneDirs(dirs, filters)
 	assert.Len(t, prunedDirs, 14)
 }

--- a/sysutil/mock_clock.go
+++ b/sysutil/mock_clock.go
@@ -35,6 +35,7 @@ func (m *MockClockInterface) EXPECT() *MockClockInterfaceMockRecorder {
 
 // Now mocks base method
 func (m *MockClockInterface) Now() time.Time {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Now")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
@@ -42,11 +43,13 @@ func (m *MockClockInterface) Now() time.Time {
 
 // Now indicates an expected call of Now
 func (mr *MockClockInterfaceMockRecorder) Now() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockClockInterface)(nil).Now))
 }
 
 // Since mocks base method
 func (m *MockClockInterface) Since(arg0 time.Time) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Since", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -54,15 +57,18 @@ func (m *MockClockInterface) Since(arg0 time.Time) time.Duration {
 
 // Since indicates an expected call of Since
 func (mr *MockClockInterfaceMockRecorder) Since(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Since", reflect.TypeOf((*MockClockInterface)(nil).Since), arg0)
 }
 
 // Sleep mocks base method
 func (m *MockClockInterface) Sleep(arg0 time.Duration) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Sleep", arg0)
 }
 
 // Sleep indicates an expected call of Sleep
 func (mr *MockClockInterfaceMockRecorder) Sleep(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleep", reflect.TypeOf((*MockClockInterface)(nil).Sleep), arg0)
 }


### PR DESCRIPTION
This PR adds a prometheus collector which exports the kube-applier configuration annotations as metrics:
- `kube_applier_enabled{namespace="$namespace"} {0,1}`
- `kube_applier_dry_run{namespace="$namespace"} {0,1}`
- `kube_applier_prune{namespace="$namespace"} {0,1}`

Running `kube.NamespaceAnnotations` for each namespace was significantly costly and more than tripled the response time of the `/__/metrics` endpoint. When the calls are batched into one with `kube.NamespaceAnnotationsBatch` the impact on response time is negligible. 

I moved the `pruneDirs` function out of the `run` package and into `sysutil` as it's now shared between the `run` and `metrics` package.