### PR TITLE
fix kubectl output parsing for result_summary metric

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -131,14 +131,15 @@ func parseKubectlOutput(output string) []Result {
 	var results []Result
 	for _, line := range lines {
 		o := strings.Split(line, " ")
-		if len(o) < 3 {
+		if len(o) < 2 {
 			continue
 		}
 
+		os := strings.Split(o[0], "/")
 		results = append(results, Result{
-			Type:   o[0],
-			Name:   strings.Trim(o[1], "\""),
-			Action: o[2],
+			Type:   os[0],
+			Name:   os[1],
+			Action: o[1],
 		})
 	}
 

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestParseKubectlOutput(t *testing.T) {
-	output := `namespace "namespaceName" configured
-limitrange "limit-range" configured
-role.rbac.authorization.k8s.io "auth" unchanged
-rolebinding.rbac.authorization.k8s.io "rolebinding" unchanged
-serviceaccount "account" unchanged
-networkpolicy.networking.k8s.io "default" unchanged
-service "serviceName" unchanged
-deployment.apps "deploymentName" unchanged`
+	output := `namespace/namespaceName configured
+limitrange/limit-range configured
+role.rbac.authorization.k8s.io/auth unchanged
+rolebinding.rbac.authorization.k8s.io/rolebinding unchanged
+serviceaccount/account unchanged
+networkpolicy.networking.k8s.io/default unchanged
+service/serviceName unchanged
+deployment.apps/deploymentName unchanged`
 
 	want := []Result{
 		{"namespace", "namespaceName", "configured"},
@@ -34,15 +34,15 @@ deployment.apps "deploymentName" unchanged`
 	}
 }
 
-func TestParseKubectlDryRunOutput(t *testing.T) {
-	output := `namespace "namespaceName" configured (dry run)
-limitrange "limit-range" configured (dry run)
-role.rbac.authorization.k8s.io "auth" configured (dry run)
-rolebinding.rbac.authorization.k8s.io "rolebinding" configured (dry run)
-serviceaccount "account" configured (dry run)
-networkpolicy.networking.k8s.io "default" configured (dry run)
-service "serviceName" configured (dry run)
-deployment.apps "deploymentName" configured (dry run)`
+func TestParseKubectlServerDryRunOutput(t *testing.T) {
+	output := `namespace/namespaceName configured (server dry run)
+limitrange/limit-range configured (server dry run)
+role.rbac.authorization.k8s.io/auth configured (server dry run)
+rolebinding.rbac.authorization.k8s.io/rolebinding configured (server dry run)
+serviceaccount/account configured (server dry run)
+networkpolicy.networking.k8s.io/default configured (server dry run)
+service/serviceName configured (server dry run)
+deployment.apps/deploymentName configured (server dry run)`
 
 	want := []Result{
 		{"namespace", "namespaceName", "configured"},


### PR DESCRIPTION
At some point it seems the plain text output of kubectl apply changed from
```
type "name" action
```
to
```
type/name action
```

This commit updates the `parseKubectlOutput` function to account for this and also adds a test for the appended`(server dry run)` which is added by `--server-dry-run`, which we switched to over `--dry-run` a while back.