### PR TITLE
use standalone kustomize binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ RUN apk --no-cache add git openssh-client tini &&\
   wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
   chmod +x /usr/local/bin/kubectl &&\
   wget -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz |\
-   tar xz -C /usr/local/bin/ && \
-  chmod +x /usr/local/bin/kustomize
+   tar xz -C /usr/local/bin/
 COPY --from=build /kube-applier /kube-applier
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,11 @@ ENV KUBECTL_VERSION v1.16.2
 ENV KUSTOMIZE_VERSION v3.4.0
 COPY templates/ /templates/
 COPY static/ /static/
-RUN apk --no-cache add git openssh-client tini curl &&\
+RUN apk --no-cache add git openssh-client tini &&\
   wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
   chmod +x /usr/local/bin/kubectl &&\
-  curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
-    grep browser_download |\
-    grep linux |\
-    cut -d '"' -f 4 |\
-    grep /kustomize/${KUSTOMIZE_VERSION} |\
-    sort | tail -n 1 |\
-    xargs curl -O -L &&\
-  tar xzf ./kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/local/bin &&\
-  rm -f ./kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz &&\
+  wget -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz |\
+   tar xz -C /usr/local/bin/ && \
   chmod +x /usr/local/bin/kustomize
 COPY --from=build /kube-applier /kube-applier
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk --no-cache add git openssh-client tini curl &&\
     sort | tail -n 1 |\
     xargs curl -O -L &&\
   tar xzf ./kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/local/bin &&\
+  rm -f ./kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz &&\
   chmod +x /usr/local/bin/kustomize
 COPY --from=build /kube-applier /kube-applier
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,21 @@ RUN apk --no-cache add git &&\
 
 FROM alpine:3.10
 ENV KUBECTL_VERSION v1.16.2
+ENV KUSTOMIZE_VERSION v3.4.0
 COPY templates/ /templates/
 COPY static/ /static/
-RUN apk --no-cache add git openssh-client tini &&\
+RUN apk --no-cache add git openssh-client tini curl &&\
   wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
-  chmod +x /usr/local/bin/kubectl
+  chmod +x /usr/local/bin/kubectl &&\
+  curl -s https://api.github.com/repos/kubernetes-sigs/kustomize/releases |\
+    grep browser_download |\
+    grep linux |\
+    cut -d '"' -f 4 |\
+    grep /kustomize/${KUSTOMIZE_VERSION} |\
+    sort | tail -n 1 |\
+    xargs curl -O -L &&\
+  tar xzf ./kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -C /usr/local/bin &&\
+  chmod +x /usr/local/bin/kustomize
 COPY --from=build /kube-applier /kube-applier
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/kube/client.go
+++ b/kube/client.go
@@ -107,13 +107,13 @@ func (c *Client) Configure() error {
 // Apply attempts to "kubectl apply" the files located at path. It returns the
 // full apply command and its output.
 //
-// kustomize - Do a `kubectl apply -k` on the path, set to if there is a
+// kustomize - Do a `kustomize build | kubectl apply -f -` on the path, set to if there is a
 //             `kustomization.yaml` found in the path
 func (c *Client) Apply(path, namespace string, dryRun, prune, kustomize bool) (string, string, error) {
 	var args []string
 
 	if kustomize {
-		args = []string{"kubectl", "apply", fmt.Sprintf("--server-dry-run=%t", dryRun), "-k", path, "-n", namespace}
+		args = []string{"kustomize", "build", path, "|", "kubectl", "apply", fmt.Sprintf("--server-dry-run=%t", dryRun), "-f", "-", "-n", namespace}
 	} else {
 		args = []string{"kubectl", "apply", fmt.Sprintf("--server-dry-run=%t", dryRun), "-R", "-f", path, "-n", namespace}
 	}


### PR DESCRIPTION
updates kustomize from v2.0.3 bundled with kubectl to v3.4.0. will need some cleanup in the manifests as it exposes us to https://github.com/kubernetes-sigs/kustomize/issues/1351