### PR TITLE
log and timeout when waiting for src dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ const (
 	// Number of seconds to wait in between attempts to locate the repo at the specified path.
 	// Git-sync atomically places the repo at the specified path once it is finished pulling, so it will not be present immediately.
 	waitForRepoInterval = 1 * time.Second
+	waitForRepoTimeout  = 120 * time.Second
 )
 
 var (
@@ -105,7 +106,7 @@ func main() {
 
 	clock := &sysutil.Clock{}
 
-	if err := sysutil.WaitForDir(repoPath, clock, waitForRepoInterval); err != nil {
+	if err := sysutil.WaitForDir(repoPath, waitForRepoInterval, waitForRepoTimeout); err != nil {
 		log.Logger.Error("error", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
example log:

```
2019-12-19T20:20:31.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:32.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:33.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:34.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:35.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:36.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:37.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:38.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:39.387Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/: no such file or directory"
2019-12-19T20:20:40.387Z [ERROR] kube-applier: error: EXTRA_VALUE_AT_END="Error: timeout waiting for dir: /src/manifests/"
```

this can be a bit chatty waiting for git sync to fetch so we could potentially lower the log level to info(?) It just didn't feel right printing an error as info.