### PR TITLE
make release 2.3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ namespace:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/utilitywarehouse/kube-applier//manifests/base?ref=2.3.6
+- github.com/utilitywarehouse/kube-applier//manifests/base?ref=2.3.7
 ```
 
 and patch as per example:

--- a/manifests/base/kube-applier.yaml
+++ b/manifests/base/kube-applier.yaml
@@ -56,7 +56,7 @@ spec:
           mountPath: /root/
       containers:
       - name: kube-applier
-        image: quay.io/utilitywarehouse/kube-applier:2.3.6
+        image: quay.io/utilitywarehouse/kube-applier:2.3.7
         env:
         - name: REPO_PATH
           value: "/src/manifests/base/"

--- a/manifests/example/kustomization.yaml
+++ b/manifests/example/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../base/
-#  - github.com/utilitywarehouse/kube-applier//manifests/base?ref=2.3.6
+#  - github.com/utilitywarehouse/kube-applier//manifests/base?ref=2.3.7
 
 resources:
   - kube-applier-ingress.yaml


### PR DESCRIPTION
Release notes:
- log and timeout when waiting for src dir (3ddb6c5)
- parse kubectl output for metrics via regex (74c87bc)
- use standalone kustomize binary (5e152cd)