### PR TITLE
fix kustomize zombies

### DIFF
--- a/kube/client.go
+++ b/kube/client.go
@@ -153,6 +153,12 @@ func (c *Client) Apply(path, namespace string, dryRun, prune, kustomize bool, pr
 			fmt.Printf("%s", err)
 			return cmdStr, "", err
 		}
+		defer func() {
+			err = kustomizeCmd.Wait()
+			if err != nil {
+				fmt.Printf("%s", err)
+			}
+		}()
 	} else {
 		cmdStr = strings.Join(args, " ")
 	}


### PR DESCRIPTION
Ever since kube-applier started piping kustomize output to kubectl, it's been leaving kustomize zombies for every invocation:
```
PID   PPID  USER     STAT COMMAND
    1     0 root     S    /sbin/tini -- /kube-applier
    7     1 root     S    /kube-applier
   23     7 root     Z    [kustomize]
  461     7 root     Z    [kustomize]
  526     7 root     Z    [kustomize]
  590     7 root     Z    [kustomize]
  613     7 root     Z    [kustomize]
  634     7 root     Z    [kustomize]
  654     7 root     Z    [kustomize]
  719     7 root     Z    [kustomize]
  739     7 root     Z    [kustomize]
  805     7 root     Z    [kustomize]
  956     7 root     Z    [kustomize]
 1021     7 root     Z    [kustomize]
```

This is happening, I believe, because the system call`wait()` isn't called on the command and so it is never released. Calling `kustomizeCmd.Wait()` at the end of the `Apply` function resolves this issue.