### PR TITLE
log at debug level when waiting for the src dir

### DIFF
--- a/sysutil/filesystem.go
+++ b/sysutil/filesystem.go
@@ -28,6 +28,7 @@ func ListDirs(rootPath string) ([]string, error) {
 
 // WaitForDir returns when the specified directory is located in the filesystem, or if there is an error opening the directory once it is found.
 func WaitForDir(path string, interval, timeout time.Duration) error {
+	log.Logger.Info("Waiting for the source directory", "path", path, "timeout", timeout.String())
 
 	to := time.After(timeout)
 
@@ -52,13 +53,14 @@ func WaitForDir(path string, interval, timeout time.Duration) error {
 						err,
 					)
 				}
-				log.Logger.Warn("Failed to get dir info", err)
+				log.Logger.Debug("Failed to get dir info", "path", path, "error", err)
 			} else if !f.IsDir() {
 				return fmt.Errorf(
 					"Error: %v is not a directory",
 					path,
 				)
 			} else {
+				log.Logger.Info("Found the source directory", "path", path)
 				return nil
 			}
 		}


### PR DESCRIPTION
I've observed that it typically takes about 1m for the src dir to become available when using git-sync to clone our kubernetes manifests. With the log messages as they are now, this results in ~60 messages logged at WARN level before the directory is found.

```
...
2020-01-27T15:02:49.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:50.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:51.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:52.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:53.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:54.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
2020-01-27T15:02:55.338Z [WARN]  kube-applier: Failed to get dir info: EXTRA_VALUE_AT_END="stat /src/manifests/{cluster}: no such file or directory"
......
```

This seems wrong and could potentially be misleading, given that this is essentially the application behaving as expected. So,  I've changed the log level of that message to DEBUG and also added a couple of INFO level messages to communicate what is happening.