### PR TITLE
make the repo wait timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ kube-applier serves a [status page](#status-ui) and provides
   be applied. Supports [shell file name
   patterns](https://golang.org/pkg/path/filepath/#Match).
 
+- `REPO_TIMEOUT_SECONDS` - (int) Number of seconds to wait for the directory
+  indicated by `REPO_PATH` to exist (default is 120).
+
 - `SERVER` - (string) Address of the Kubernetes API server. By default,
   kube-applier uses in-cluster configuration targetting local internal endpoint.
   Address must be specified with this environment variable (which is then written

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 	clock := &sysutil.Clock{}
 
 	if err := sysutil.WaitForDir(repoPath, waitForRepoInterval, waitForRepoTimeout); err != nil {
-		log.Logger.Error("error", err)
+		log.Logger.Error("problem waiting for repo", "path", repoPath, "error", err)
 		os.Exit(1)
 	}
 

--- a/sysutil/filesystem.go
+++ b/sysutil/filesystem.go
@@ -39,7 +39,7 @@ func WaitForDir(path string, interval, timeout time.Duration) error {
 
 		case <-to:
 			return fmt.Errorf(
-				"Error: timeout waiting for dir: %v",
+				"timeout waiting for dir: %v",
 				path,
 			)
 
@@ -56,7 +56,7 @@ func WaitForDir(path string, interval, timeout time.Duration) error {
 				log.Logger.Debug("Failed to get dir info", "path", path, "error", err)
 			} else if !f.IsDir() {
 				return fmt.Errorf(
-					"Error: %v is not a directory",
+					"%v is not a directory",
 					path,
 				)
 			} else {


### PR DESCRIPTION
It's not unreasonable for a repository to take longer than 2 minutes to clone in the case of
slow network or disks or when the repository is particularly large.

Additionally, this PR fixes a panic when logging the errors produced by WaitForDir. We were passing the error returned by WaitForDir as the second argument to `log.Logger.Error`, which is expected to be a string.

This was producing a panic:
```
panic: interface conversion: interface {} is *errors.errorString, not string
```

I've amended the arguments and also tweaked the format of the logs a bit.