### PR TITLE
Revert "use standalone kustomize binary"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,11 @@ RUN apk --no-cache add git &&\
 
 FROM alpine:3.11
 ENV KUBECTL_VERSION v1.16.2
-ENV KUSTOMIZE_VERSION v3.4.0
 COPY templates/ /templates/
 COPY static/ /static/
 RUN apk --no-cache add git openssh-client tini &&\
   wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl &&\
-  chmod +x /usr/local/bin/kubectl &&\
-  wget -O - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz |\
-    tar xz -C /usr/local/bin/
+  chmod +x /usr/local/bin/kubectl
 COPY --from=build /kube-applier /kube-applier
 
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
This reverts commit 5e152cdf56bb5f61c21c5b4a3c2946e93cb4ac85.

for our use cases compatibility with the built in kubernetes tooling is important.
we kubectl diff -k quite a lot in order to assess impact of deployments, and using
the external kustomize causes incompatibilities between kubectl and kustomize
build. the bit that stuck out for us is that the field `env` in `configMapGenerator`
is an array in the external binary (v3.4.0), vs a scalar in the built in one.