### PR TITLE
add metric to track the finish time of the last run 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,11 @@ custom metrics are included:
   for each exit code returned by executions of `kubectl`, labelled with the
   namespace and exit code.
 
+- **last_run_timestamp_seconds** - A
+  [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
+  that reports the last time a run finished, expressed in seconds
+  since the Unix Epoch.
+
 The Prometheus [HTTP API](https://prometheus.io/docs/querying/api/) (also see
 the [Go
 library](https://github.com/prometheus/client_golang/tree/master/api/prometheus))

--- a/metrics/mock_prometheus.go
+++ b/metrics/mock_prometheus.go
@@ -7,6 +7,7 @@ package metrics
 import (
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+	time "time"
 )
 
 // MockPrometheusInterface is a mock of PrometheusInterface interface
@@ -34,40 +35,60 @@ func (m *MockPrometheusInterface) EXPECT() *MockPrometheusInterfaceMockRecorder 
 
 // UpdateKubectlExitCodeCount mocks base method
 func (m *MockPrometheusInterface) UpdateKubectlExitCodeCount(arg0 string, arg1 int) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateKubectlExitCodeCount", arg0, arg1)
 }
 
 // UpdateKubectlExitCodeCount indicates an expected call of UpdateKubectlExitCodeCount
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateKubectlExitCodeCount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKubectlExitCodeCount", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateKubectlExitCodeCount), arg0, arg1)
 }
 
 // UpdateNamespaceSuccess mocks base method
 func (m *MockPrometheusInterface) UpdateNamespaceSuccess(arg0 string, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateNamespaceSuccess", arg0, arg1)
 }
 
 // UpdateNamespaceSuccess indicates an expected call of UpdateNamespaceSuccess
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateNamespaceSuccess(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespaceSuccess", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateNamespaceSuccess), arg0, arg1)
 }
 
 // UpdateRunLatency mocks base method
 func (m *MockPrometheusInterface) UpdateRunLatency(arg0 float64, arg1 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateRunLatency", arg0, arg1)
 }
 
 // UpdateRunLatency indicates an expected call of UpdateRunLatency
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateRunLatency(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRunLatency", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateRunLatency), arg0, arg1)
 }
 
 // UpdateResultSummary mocks base method
 func (m *MockPrometheusInterface) UpdateResultSummary(arg0 map[string]string) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateResultSummary", arg0)
 }
 
 // UpdateResultSummary indicates an expected call of UpdateResultSummary
 func (mr *MockPrometheusInterfaceMockRecorder) UpdateResultSummary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResultSummary", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateResultSummary), arg0)
+}
+
+// UpdateLastRunTimestamp mocks base method
+func (m *MockPrometheusInterface) UpdateLastRunTimestamp(arg0 time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateLastRunTimestamp", arg0)
+}
+
+// UpdateLastRunTimestamp indicates an expected call of UpdateLastRunTimestamp
+func (mr *MockPrometheusInterfaceMockRecorder) UpdateLastRunTimestamp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastRunTimestamp", reflect.TypeOf((*MockPrometheusInterface)(nil).UpdateLastRunTimestamp), arg0)
 }

--- a/run/runner.go
+++ b/run/runner.go
@@ -75,6 +75,7 @@ func (r *Runner) run() (*Result, error) {
 	r.Metrics.UpdateResultSummary(results)
 
 	r.Metrics.UpdateRunLatency(r.Clock.Since(start).Seconds(), success)
+	r.Metrics.UpdateLastRunTimestamp(finish)
 
 	newRun := Result{start, finish, hash, commitLog, successes, failures, r.DiffURLFormat}
 	return &newRun, nil


### PR DESCRIPTION
`last_run_timestamp_seconds` allows you to ensure that runs are happening
regularly within an expected window of time. This can catch instances where
kube-applier hangs mid-run or isn't triggering according to `FULL_RUN_INTERVAL`.

