### PR TITLE
retrieve prunable resources in the runner and pass to apply

### DIFF
--- a/main.go
+++ b/main.go
@@ -178,6 +178,7 @@ func main() {
 		GitUtil:         gitUtil,
 		Clock:           clock,
 		Metrics:         metrics,
+		KubeClient:      kubeClient,
 		DiffURLFormat:   diffURLFormat,
 		RunQueue:        runQueue,
 		RunResults:      runResults,


### PR DESCRIPTION
I think it fits better there and allows us to skip the apply run and return an error in cases where there is a problem, rather than awkwardly returning from `BatchApplier.Apply`.