### PR TITLE
kustomize v3.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add git &&\
 
 FROM alpine:3.11
 ENV KUBECTL_VERSION v1.17.3
-ENV KUSTOMIZE_VERSION v3.5.5
+ENV KUSTOMIZE_VERSION v3.6.1
 COPY templates/ /templates/
 COPY static/ /static/
 RUN apk --no-cache add git openssh-client tini &&\


### PR DESCRIPTION
This includes a fix for a pretty big regression in 3.5.5 where using commit hash as a ref when pulling remote files didn't work:
- https://github.com/kubernetes-sigs/kustomize/pull/2537