### PR TITLE
Replace --server-dry-run with --dry-run=server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ kube-applier serves a [status page](#status-ui) and provides
 - <a name="run-interval"></a>`FULL_RUN_INTERVAL_SECONDS` - (int) Number of
   seconds between automatic full runs (default is 3600). Set to 0 to disable.
 
-- `DRY_RUN` - (bool) If true, kubectl command will be run with --server-dry-run
+- `DRY_RUN` - (bool) If true, kubectl command will be run with --dry-run=server
   flag. This means live configuration of the cluster is not changed.
 
 - `LOG_LEVEL` - (string) trace|debug|info|warn|error case insensitive

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -13,7 +13,7 @@ var execCommand = exec.Command
 
 // ClientInterface allows for mocking out the functionality of Client when testing the full process of an apply run.
 type ClientInterface interface {
-	Apply(path, namespace string, dryRun, kustomize bool, pruneWhitelist []string) (string, string, error)
+	Apply(path, namespace, dryRunStrategy string, kustomize bool, pruneWhitelist []string) (string, string, error)
 }
 
 // Client enables communication with the Kubernetes API Server through kubectl commands.
@@ -27,13 +27,13 @@ type Client struct {
 //
 // kustomize - Do a `kustomize build | kubectl apply -f -` on the path, set to if there is a
 //             `kustomization.yaml` found in the path
-func (c *Client) Apply(path, namespace string, dryRun, kustomize bool, pruneWhitelist []string) (string, string, error) {
+func (c *Client) Apply(path, namespace, dryRunStrategy string, kustomize bool, pruneWhitelist []string) (string, string, error) {
 	var args []string
 
 	if kustomize {
-		args = []string{"kubectl", "apply", fmt.Sprintf("--server-dry-run=%t", dryRun), "-f", "-", "-n", namespace}
+		args = []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-f", "-", "-n", namespace}
 	} else {
-		args = []string{"kubectl", "apply", fmt.Sprintf("--server-dry-run=%t", dryRun), "-R", "-f", path, "-n", namespace}
+		args = []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-R", "-f", path, "-n", namespace}
 	}
 
 	if len(pruneWhitelist) > 0 {

--- a/kubectl/mock_client.go
+++ b/kubectl/mock_client.go
@@ -33,9 +33,9 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 }
 
 // Apply mocks base method
-func (m *MockClientInterface) Apply(path, namespace string, dryRun, kustomize bool, pruneWhitelist []string) (string, string, error) {
+func (m *MockClientInterface) Apply(path, namespace, dryRunStrategy string, kustomize bool, pruneWhitelist []string) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", path, namespace, dryRun, kustomize, pruneWhitelist)
+	ret := m.ctrl.Call(m, "Apply", path, namespace, dryRunStrategy, kustomize, pruneWhitelist)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -43,7 +43,7 @@ func (m *MockClientInterface) Apply(path, namespace string, dryRun, kustomize bo
 }
 
 // Apply indicates an expected call of Apply
-func (mr *MockClientInterfaceMockRecorder) Apply(path, namespace, dryRun, kustomize, pruneWhitelist interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) Apply(path, namespace, dryRunStrategy, kustomize, pruneWhitelist interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClientInterface)(nil).Apply), path, namespace, dryRun, kustomize, pruneWhitelist)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClientInterface)(nil).Apply), path, namespace, dryRunStrategy, kustomize, pruneWhitelist)
 }

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -108,8 +108,13 @@ func (a *BatchApplier) Apply(applyList []string, options *ApplyOptions) ([]Apply
 			kustomize = true
 		}
 
+		dryRunStrategy := "none"
+		if a.DryRun || dryRun {
+			dryRunStrategy = "server"
+		}
+
 		var cmd, output string
-		cmd, output, err = a.KubectlClient.Apply(path, ns, a.DryRun || dryRun, kustomize, pruneWhitelist)
+		cmd, output, err = a.KubectlClient.Apply(path, ns, dryRunStrategy, kustomize, pruneWhitelist)
 		success := (err == nil)
 		appliedFile := ApplyAttempt{path, cmd, output, ""}
 		if success {

--- a/run/batch_applier_test.go
+++ b/run/batch_applier_test.go
@@ -75,13 +75,13 @@ func TestBatchApplierApplySuccess(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("file3", "file3", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -116,13 +116,13 @@ func TestBatchApplierApplyFail(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnFailure("file1", "file1", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectFailureMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnFailure("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectFailureMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnFailure("file3", "file3", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectFailureMetric("file3", metrics),
 	)
 	failures := []ApplyAttempt{
@@ -157,16 +157,16 @@ func TestBatchApplierApplyPartial(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3", "file4"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnFailure("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectFailureMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("file3", "file3", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file4", kubeClient),
-		expectApplyAndReturnFailure("file4", "file4", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("file4", "file4", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectFailureMetric("file4", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -205,13 +205,13 @@ func TestBatchApplierApplySuccessDryRun(t *testing.T) {
 
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("file3", "file3", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -247,13 +247,13 @@ func TestBatchApplierApplySuccessDryRunNamespaces(t *testing.T) {
 	applyList := []string{"repo/file1", "file2", "repo/file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("repo/file1", "file1", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("repo/file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("repo/file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("repo/file3", "file3", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("repo/file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("repo/file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -289,13 +289,13 @@ func TestBatchApplierApplySuccessDryRunAndDryRunNamespaces(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("file3", "file3", true, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -332,7 +332,7 @@ func TestBatchApplierApplyDisabledNamespaces(t *testing.T) {
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "false"}, "file1", kubeClient),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "false"}, "file3", kubeClient),
 	)
@@ -368,7 +368,7 @@ func TestBatchApplierApplyInvalidAnnotation(t *testing.T) {
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "unsupportedOption"}, "file1", kubeClient),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "unsupportedOption"}, "file3", kubeClient),
 	)
@@ -402,10 +402,10 @@ func TestBatchApplierApplySuccessPruneTrue(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", Prune: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -439,7 +439,7 @@ func TestBatchApplierApplySuccessPruneClusterResources(t *testing.T) {
 	applyList := []string{"file1"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", PruneClusterResources: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, testAllResources, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", testAllResources, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -472,10 +472,10 @@ func TestBatchApplierApplySuccessPruneFalse(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", Prune: "false"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, nil, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", nil, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -517,10 +517,10 @@ func TestBatchApplierApplySuccessPruneBlacklist(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("file1", "file1", false, []string{"autoscaling/v1/HorizontalPodAutoscaler"}, kubectlClient),
+		expectApplyAndReturnSuccess("file1", "file1", "none", []string{"autoscaling/v1/HorizontalPodAutoscaler"}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", PruneClusterResources: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("file2", "file2", false, []string{"autoscaling/v1/HorizontalPodAutoscaler", "core/v1/Namespace"}, kubectlClient),
+		expectApplyAndReturnSuccess("file2", "file2", "none", []string{"autoscaling/v1/HorizontalPodAutoscaler", "core/v1/Namespace"}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -543,12 +543,12 @@ func TestBatchApplierApplySuccessPruneBlacklist(t *testing.T) {
 	applyAndAssert(t, tc)
 }
 
-func expectApplyAndReturnSuccess(file, namespace string, dryRun bool, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
-	return kubectlClient.EXPECT().Apply(file, namespace, dryRun, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, nil)
+func expectApplyAndReturnSuccess(file, namespace, dryRunStrategy string, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
+	return kubectlClient.EXPECT().Apply(file, namespace, dryRunStrategy, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, nil)
 }
 
-func expectApplyAndReturnFailure(file, namespace string, dryRun bool, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
-	return kubectlClient.EXPECT().Apply(file, namespace, dryRun, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, fmt.Errorf("error "+file))
+func expectApplyAndReturnFailure(file, namespace, dryRunStrategy string, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
+	return kubectlClient.EXPECT().Apply(file, namespace, dryRunStrategy, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, fmt.Errorf("error "+file))
 }
 
 func expectNamespaceAnnotationsAndReturn(ret kube.KAAnnotations, namespace string, kubeClient *kube.MockClientInterface) *gomock.Call {


### PR DESCRIPTION
The --server-dry-run flag is deprecated and has been removed in v1.19:
- https://github.com/kubernetes/kubernetes/pull/91308
- https://kubernetes.io/docs/setup/release/notes/#other-cleanup-or-flake
- https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/0015-dry-run.md

Note that the kubectl.Client `dryRun` bool arg could be retained, but
I figured it made sense that the interface aligns with the underlying
flag, where a string value must be provided.. happy to adjust if anyone
feels otherwise.