### PR TITLE
manifests: use REPO_RELATIVE_PATH

### DIFF
--- a/manifests/base/kube-applier.yaml
+++ b/manifests/base/kube-applier.yaml
@@ -59,7 +59,7 @@ spec:
           image: quay.io/utilitywarehouse/kube-applier:2.4.5
           env:
             - name: REPO_PATH
-              value: "/src/manifests/base/"
+              value: "/src/manifests/$(REPO_RELATIVE_PATH)"
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"
             - name: LOG_LEVEL

--- a/manifests/example/kube-applier-patch.yaml
+++ b/manifests/example/kube-applier-patch.yaml
@@ -8,8 +8,8 @@ spec:
       containers:
       - name: kube-applier
         env:
-        - name: REPO_PATH
-          value: "/src/manifests/example-env/"
+        - name: REPO_RELATIVE_PATH
+          value: "example-env"
         - name: REPO_PATH_FILTERS
           value: "my-namespace-1,my-namespace-2,team-namespace-*"
         - name: DIFF_URL_FORMAT


### PR DESCRIPTION
This removes the need to prefix REPO_PATH with /src/manifests which is
an arbitrary path.

It's also backwards compatible.