### PR TITLE
Define REPO_RELATIVE_PATH in base

### DIFF
--- a/manifests/base/kube-applier.yaml
+++ b/manifests/base/kube-applier.yaml
@@ -58,6 +58,8 @@ spec:
         - name: kube-applier
           image: quay.io/utilitywarehouse/kube-applier:2.4.5
           env:
+            - name: REPO_RELATIVE_PATH
+              value: "base"
             - name: REPO_PATH
               value: "/src/manifests/$(REPO_RELATIVE_PATH)"
             - name: DIFF_URL_FORMAT

--- a/manifests/base/kube-applier.yaml
+++ b/manifests/base/kube-applier.yaml
@@ -58,10 +58,14 @@ spec:
         - name: kube-applier
           image: quay.io/utilitywarehouse/kube-applier:2.4.5
           env:
-            - name: REPO_RELATIVE_PATH
+            - name: NAMESPACES_DIR
               value: "base"
             - name: REPO_PATH
-              value: "/src/manifests/$(REPO_RELATIVE_PATH)"
+              value: "/src/manifests/$(NAMESPACES_DIR)"
+            - name: NAMESPACES_FILTERS
+              value: ""
+            - name: REPO_PATH_FILTERS
+              value: "$(NAMESPACES_FILTERS)"
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"
             - name: LOG_LEVEL

--- a/manifests/example/kube-applier-patch.yaml
+++ b/manifests/example/kube-applier-patch.yaml
@@ -8,9 +8,9 @@ spec:
       containers:
       - name: kube-applier
         env:
-        - name: REPO_RELATIVE_PATH
+        - name: NAMESPACES_DIR
           value: "example-env"
-        - name: REPO_PATH_FILTERS
+        - name: NAMESPACES_FILTERS
           value: "my-namespace-1,my-namespace-2,team-namespace-*"
         - name: DIFF_URL_FORMAT
           value: "https://github.com/org/repo/commit/%s"


### PR DESCRIPTION
New kustomize versions will add patched env variables at the end of the
list, which means the substitution does not work. REPO_RELATIVE_PATH
needs to be defined before REPO_PATH.