### PR TITLE
Restore output on errors

### DIFF
--- a/git/gitutil.go
+++ b/git/gitutil.go
@@ -28,7 +28,7 @@ func (g *Util) HeadHashForPaths(args ...string) (string, error) {
 	return strings.Trim(hash, "'\n"), err
 }
 
-// HeadCommitLog returns the log of the current HEAD commit, including a list
+// HeadCommitLogForPaths returns the log of the current HEAD commit, including a list
 // of the files that were modified for the filtered directories
 func (g *Util) HeadCommitLogForPaths(args ...string) (string, error) {
 	cmd := []string{"log", "-1", "--name-status", "--"}

--- a/go.mod
+++ b/go.mod
@@ -19,4 +19,5 @@ require (
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -3,13 +3,23 @@ package kubectl
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os/exec"
+	"strings"
 
 	"github.com/utilitywarehouse/kube-applier/metrics"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
 )
 
-// To make testing possible
-var execCommand = exec.Command
+var (
+	// To make testing possible
+	execCommand          = exec.Command
+	omitErrOutputMessage = "Some error output has been omitted because it may contain sensitive data\n"
+)
 
 // ClientInterface allows for mocking out the functionality of Client when testing the full process of an apply run.
 type ClientInterface interface {
@@ -24,54 +34,206 @@ type Client struct {
 
 // Apply attempts to "kubectl apply" the files located at path. It returns the
 // full apply command and its output.
-//
-// kustomize - Do a `kustomize build | kubectl apply -f -` on the path, set to if there is a
-//             `kustomization.yaml` found in the path
 func (c *Client) Apply(path, namespace, dryRunStrategy string, kustomize bool, pruneWhitelist []string) (string, string, error) {
-	var args []string
-
 	if kustomize {
-		args = []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-f", "-", "-n", namespace}
-	} else {
-		args = []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-R", "-f", path, "-n", namespace}
+		return c.applyKustomize(path, namespace, dryRunStrategy, pruneWhitelist)
 	}
+	return c.apply(path, namespace, dryRunStrategy, pruneWhitelist)
+}
 
-	if len(pruneWhitelist) > 0 {
-		args = append(args, "--prune")
-		args = append(args, "--all")
-
-		for _, w := range pruneWhitelist {
-			args = append(args, "--prune-whitelist="+w)
-		}
-	}
+// apply runs `kubectl apply -f <path>`
+func (c *Client) apply(path, namespace, dryRunStrategy string, pruneWhitelist []string) (string, string, error) {
+	args := []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-R", "-f", path, "-n", namespace}
+	args = pruneArgs(args, pruneWhitelist)
 
 	kubectlCmd := exec.Command(args[0], args[1:]...)
-	cmdStr := kubectlCmd.String()
-
-	if kustomize {
-		var kustomizeStdout, kustomizeStderr bytes.Buffer
-
-		kustomizeCmd := exec.Command("kustomize", "build", path)
-		kustomizeCmd.Stdout = &kustomizeStdout
-		kustomizeCmd.Stderr = &kustomizeStderr
-
-		err := kustomizeCmd.Run()
-		if err != nil {
-			return kustomizeCmd.String(), kustomizeStderr.String(), err
-		}
-
-		kubectlCmd.Stdin = &kustomizeStdout
-		cmdStr = kustomizeCmd.String() + " | " + cmdStr
-	}
-
 	out, err := kubectlCmd.CombinedOutput()
 	if err != nil {
 		if e, ok := err.(*exec.ExitError); ok {
 			c.Metrics.UpdateKubectlExitCodeCount(namespace, e.ExitCode())
 		}
-		return cmdStr, string(out), err
+		// Filter potential secret leaks out of the output
+		return kubectlCmd.String(), filterErrOutput(string(out)), err
 	}
 	c.Metrics.UpdateKubectlExitCodeCount(path, 0)
 
-	return cmdStr, string(out), err
+	return kubectlCmd.String(), string(out), nil
+}
+
+// applyKustomize does a `kustomize build | kubectl apply -f -` on the path
+func (c *Client) applyKustomize(path, namespace, dryRunStrategy string, pruneWhitelist []string) (string, string, error) {
+	var kustomizeStdout, kustomizeStderr bytes.Buffer
+
+	kustomizeCmd := exec.Command("kustomize", "build", path)
+	kustomizeCmd.Stdout = &kustomizeStdout
+	kustomizeCmd.Stderr = &kustomizeStderr
+
+	err := kustomizeCmd.Run()
+	if err != nil {
+		return kustomizeCmd.String(), kustomizeStderr.String(), err
+	}
+
+	// Split the stdout into secrets and other resources
+	stdout, err := ioutil.ReadAll(&kustomizeStdout)
+	if err != nil {
+		return kustomizeCmd.String(), "error reading kustomize output", err
+	}
+	resources, secrets, err := splitSecrets(stdout)
+	if err != nil {
+		return kustomizeCmd.String(), "error extracting secrets from kustomize output", err
+	}
+	if len(resources) == 0 && len(secrets) == 0 {
+		return kustomizeCmd.String(), "", fmt.Errorf("No resources were extracted from the kustomize output")
+	}
+
+	args := []string{"kubectl", "apply", fmt.Sprintf("--dry-run=%s", dryRunStrategy), "-f", "-", "-n", namespace}
+
+	// This is the command we are effectively applying. In actuality we're splitting it into two
+	// separate invocations of kubectl but we'll return this as the command
+	// string.
+	displayArgs := pruneArgs(args, pruneWhitelist)
+	kubectlCmd := exec.Command(displayArgs[0], displayArgs[1:]...)
+	cmdStr := kustomizeCmd.String() + " | " + kubectlCmd.String()
+
+	var kubectlOut []byte
+
+	if len(resources) > 0 {
+		resourcesArgs := args
+
+		// Don't prune secrets
+		resourcesPruneWhitelist := []string{}
+		for _, w := range pruneWhitelist {
+			if w != "core/v1/Secret" {
+				resourcesPruneWhitelist = append(resourcesPruneWhitelist, w)
+			}
+		}
+		resourcesArgs = pruneArgs(resourcesArgs, resourcesPruneWhitelist)
+
+		resourcesKubectlCmd := exec.Command(resourcesArgs[0], resourcesArgs[1:]...)
+		resourcesKubectlCmd.Stdin = bytes.NewReader(resources)
+
+		out, err := resourcesKubectlCmd.CombinedOutput()
+		kubectlOut = append(kubectlOut, out...)
+		if err != nil {
+			if e, ok := err.(*exec.ExitError); ok {
+				c.Metrics.UpdateKubectlExitCodeCount(namespace, e.ExitCode())
+			}
+			return cmdStr, string(kubectlOut), err
+		}
+		c.Metrics.UpdateKubectlExitCodeCount(path, 0)
+	}
+
+	if len(secrets) > 0 {
+		secretsArgs := args
+
+		// Only prune secrets
+		var secretsPruneWhitelist []string
+		for _, w := range pruneWhitelist {
+			if w == "core/v1/Secret" {
+				secretsPruneWhitelist = append(secretsPruneWhitelist, w)
+			}
+		}
+		secretsArgs = pruneArgs(secretsArgs, secretsPruneWhitelist)
+
+		secretsKubectlCmd := exec.Command(secretsArgs[0], secretsArgs[1:]...)
+		secretsKubectlCmd.Stdin = bytes.NewReader(secrets)
+
+		out, err := secretsKubectlCmd.CombinedOutput()
+		if err != nil {
+			if e, ok := err.(*exec.ExitError); ok {
+				c.Metrics.UpdateKubectlExitCodeCount(namespace, e.ExitCode())
+			}
+			// Don't append the actual output, as the error output
+			// from kubectl can leak the content of secrets
+			kubectlOut = append(kubectlOut, []byte(omitErrOutputMessage)...)
+			return cmdStr, string(kubectlOut), err
+		}
+		c.Metrics.UpdateKubectlExitCodeCount(path, 0)
+		kubectlOut = append(kubectlOut, out...)
+	}
+
+	return cmdStr, string(kubectlOut), nil
+}
+
+// pruneArgs appends prune arguments to a list of arguments
+func pruneArgs(args []string, pruneWhitelist []string) []string {
+	if len(pruneWhitelist) > 0 {
+		args = append(args, []string{"--prune", "--all"}...)
+		for _, w := range pruneWhitelist {
+			args = append(args, "--prune-whitelist="+w)
+		}
+	}
+
+	return args
+}
+
+// filterErrOutput squashes output that may contain potential leaked secrets
+func filterErrOutput(out string) string {
+	if strings.Contains(out, "Secret") || strings.Contains(out, "base64") {
+		return omitErrOutputMessage
+	}
+
+	return out
+}
+
+// splitSecrets will take a yaml file and separate the resources into Secrets
+// and other resources. This allows Secrets to be applied separately to other
+// resources.
+func splitSecrets(yamlData []byte) (resources, secrets []byte, err error) {
+	objs, err := splitYAML(yamlData)
+	if err != nil {
+		return resources, secrets, err
+	}
+
+	secretsDocs := [][]byte{}
+	resourcesDocs := [][]byte{}
+	for _, obj := range objs {
+		y, err := yaml.Marshal(obj)
+		if err != nil {
+			return resources, secrets, err
+		}
+		if obj.Object["kind"] == "Secret" {
+			secretsDocs = append(secretsDocs, y)
+		} else {
+			resourcesDocs = append(resourcesDocs, y)
+		}
+	}
+
+	secrets = bytes.Join(secretsDocs, []byte("---\n"))
+	resources = bytes.Join(resourcesDocs, []byte("---\n"))
+
+	return resources, secrets, nil
+}
+
+// splitYAML splits a YAML file into unstructured objects. Returns list of all unstructured objects
+// found in the yaml. If an error occurs, returns objects that have been parsed so far too.
+//
+// Taken from the gitops-engine:
+//  - https://github.com/argoproj/gitops-engine/blob/cc0fb5531c29c193291a7f97a50921f544b2d3b9/pkg/utils/kube/kube.go#L282-L310
+func splitYAML(yamlData []byte) ([]*unstructured.Unstructured, error) {
+	// Similar way to what kubectl does
+	// https://github.com/kubernetes/cli-runtime/blob/master/pkg/resource/visitor.go#L573-L600
+	// Ideally k8s.io/cli-runtime/pkg/resource.Builder should be used instead of this method.
+	// E.g. Builder does list unpacking and flattening and this code does not.
+	d := kubeyaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlData), 4096)
+	var objs []*unstructured.Unstructured
+	for {
+		ext := runtime.RawExtension{}
+		if err := d.Decode(&ext); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return objs, fmt.Errorf("failed to unmarshal manifest: %v", err)
+		}
+		ext.Raw = bytes.TrimSpace(ext.Raw)
+		if len(ext.Raw) == 0 || bytes.Equal(ext.Raw, []byte("null")) {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal(ext.Raw, u); err != nil {
+			return objs, fmt.Errorf("failed to unmarshal manifest: %v", err)
+		}
+		objs = append(objs, u)
+	}
+	return objs, nil
 }

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -17,7 +17,10 @@ import (
 
 var (
 	// To make testing possible
-	execCommand          = exec.Command
+	execCommand = exec.Command
+	// The output is omitted if it contains any of these terms
+	// when there is an error running `kubectl apply -f <path>`
+	omitErrOutputTerms   = []string{"Secret", "base64"}
 	omitErrOutputMessage = "Some error output has been omitted because it may contain sensitive data\n"
 )
 
@@ -167,10 +170,13 @@ func pruneArgs(args []string, pruneWhitelist []string) []string {
 	return args
 }
 
-// filterErrOutput squashes output that may contain potential leaked secrets
+// filterErrOutput squashes output that may contain potentially sensitive
+// information
 func filterErrOutput(out string) string {
-	if strings.Contains(out, "Secret") || strings.Contains(out, "base64") {
-		return omitErrOutputMessage
+	for _, term := range omitErrOutputTerms {
+		if strings.Contains(out, term) {
+			return omitErrOutputMessage
+		}
 	}
 
 	return out

--- a/kubectl/client_test.go
+++ b/kubectl/client_test.go
@@ -1,0 +1,366 @@
+package kubectl
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestFilterErrOutput(t *testing.T) {
+	testCases := []struct {
+		output   string
+		filtered bool
+	}{
+		{
+			output:   `Error from server (BadRequest): error when creating "secrets/test.yaml": Secret in version "v1" cannot be handled as a Secret: v1.Secret.ObjectMeta: v1.ObjectMeta.TypeMeta: Kind: Data: decode base64: illegal base64 data at input byte 4, error found in #10 byte of ...|:"invalid"},"kind":"|..., bigger context ...|{"apiVersion":"v1","data":{"something":"invalid"},"kind":"Secret","metadata":{"annotations":{"kube|...`,
+			filtered: true,
+		},
+		{
+			output:   `The request is invalid: patch: Invalid value: "map[data:map[something:invalid] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"something\":\"invalid\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"sys-auth\"},\"type\":\"Opaque\"}\n]]]": error decoding from json: illegal base64 data at input byte 4`,
+			filtered: true,
+		},
+		{
+			output:   `The request is invalid: patch: Invalid value: "map[data:map[something:map[]] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"something\":{}},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"sys-auth\"},\"type\":\"Opaque\"}\n]]]": cannot restore slice from map`,
+			filtered: true,
+		},
+		{
+			output:   `Error from server (BadRequest): error when creating "secrets/test.yaml": Secret in version "v1" cannot be handled as a Secret: v1.Secret.Data: base64Codec: invalid input, error found in #10 byte of ...|omething":{}},"kind"|..., bigger context ...|{"apiVersion":"v1","data":{"something":{}},"kind":"Secret","metadata":{"annotations":{"ku|...`,
+			filtered: true,
+		},
+		{
+			output: `namespace/sys-auth configured
+rolebinding.rbac.authorization.k8s.io/vault-configmap-applier unchanged
+Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
+configmap/vault-tls configured
+clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged
+secret/k8s-auth-conf unchanged
+Error from server (BadRequest): error when creating "secrets/test.yaml": Secret in version "v1" cannot be handled as a Secret: v1.Secret.ObjectMeta: v1.ObjectMeta.TypeMeta: Kind: Data: decode base64: illegal base64 data at input byte 4, error found in #10 byte of ...|:"invalid"},"kind":"|..., bigger context ...|{"apiVersion":"v1","data":{"something":"invalid"},"kind":"Secret","metadata":{"annotations":{"kube|...
+`,
+			filtered: true,
+		},
+		{
+			output: `namespace/sys-auth configured (server dry run)
+rolebinding.rbac.authorization.k8s.io/vault-configmap-applier unchanged (server dry run)
+Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
+configmap/vault-tls configured (server dry run)
+clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged (server dry run)
+secret/k8s-auth-conf unchanged (server dry run)
+The request is invalid: patch: Invalid value: "map[data:map[something:invalid] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"something\":\"invalid\"},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"sys-auth\"},\"type\":\"Opaque\"}\n]]]": error decoding from json: illegal base64 data at input byte 4
+`,
+			filtered: true,
+		},
+		{
+			output:   `The Secret "test_" is invalid: metadata.name: Invalid value: "test_": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`,
+			filtered: true,
+		},
+		{
+			output:   `The request is invalid: patch: Invalid value: "map[data:map[invalid:map[]] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"invalid\":{}},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"labs\"}}\n]]]": unrecognized type: string`,
+			filtered: false,
+		},
+		{
+			output: `namespace/sys-auth configured (server dry run)
+rolebinding.rbac.authorization.k8s.io/vault-configmap-applier unchanged (server dry run)
+Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
+configmap/vault-tls configured (server dry run)
+clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged (server dry run)
+secret/k8s-auth-conf unchanged (server dry run)
+`,
+			filtered: false,
+		},
+		{
+			output: `namespace/sys-auth configured (server dry run)
+rolebinding.rbac.authorization.k8s.io/vault-configmap-applier unchanged (server dry run)
+Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply
+configmap/vault-tls configured (server dry run)
+clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged (server dry run)
+secret/k8s-auth-conf unchanged (server dry run)
+The request is invalid: patch: Invalid value: "map[data:map[invalid:map[]] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"invalid\":{}},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"test\",\"namespace\":\"labs\"}}\n]]]": unrecognized type: string
+`,
+			filtered: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		var want string
+		if tc.filtered {
+			want = omitErrOutputMessage
+		} else {
+			want = tc.output
+		}
+
+		got := filterErrOutput(tc.output)
+
+		if diff := deep.Equal(got, want); diff != nil {
+			t.Error(diff)
+		}
+	}
+}
+
+func TestPruneArgs(t *testing.T) {
+	testCases := []struct {
+		pruneWhitelist []string
+		args           []string
+		want           []string
+	}{
+		{
+			pruneWhitelist: []string{"core/v1/ConfigMap", "core/v1/Pod", "rbac.authorization.k8s.io/v1beta1/RoleBinding"},
+			args:           []string{"kubectl", "apply", "-f", "/src/manifests/test/example", "-n", "example"},
+			want: []string{"kubectl", "apply", "-f", "/src/manifests/test/example", "-n", "example", "--prune", "--all",
+				"--prune-whitelist=core/v1/ConfigMap",
+				"--prune-whitelist=core/v1/Pod",
+				"--prune-whitelist=rbac.authorization.k8s.io/v1beta1/RoleBinding",
+			},
+		},
+		{
+			pruneWhitelist: []string{},
+			args:           []string{"kubectl", "apply", "-f", "/src/manifests/test/example", "-n", "example"},
+			want:           []string{"kubectl", "apply", "-f", "/src/manifests/test/example", "-n", "example"},
+		},
+	}
+
+	for _, tc := range testCases {
+		got := pruneArgs(tc.args, tc.pruneWhitelist)
+
+		if diff := deep.Equal(got, tc.want); diff != nil {
+			t.Error(diff)
+		}
+	}
+}
+
+func TestSplitSecrets(t *testing.T) {
+	testCases := []struct {
+		yamlData      []byte
+		resourcesData []byte
+		secretsData   []byte
+	}{
+		{
+			yamlData: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: example 
+  namespace: example-ns
+stringData:
+  some-key: some-value
+  some-other-key: some-other-value
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    kube-applier.io/dry-run: "false"
+    kube-applier.io/enabled: "true"
+    kube-applier.io/prune: "true"
+  labels:
+    name: example-ns
+    some-label: some-value
+  name: example-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    some-annotation: some-value
+  name: example 
+---
+apiVersion: v1
+data:
+  some-value: c2Vuc2l0aXZlCg==
+kind: Secret
+metadata:
+  name: example-1 
+  namespace: example-ns
+type: Opaque
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: kube-applier
+  namespace: example-ns 
+`),
+			resourcesData: []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    kube-applier.io/dry-run: "false"
+    kube-applier.io/enabled: "true"
+    kube-applier.io/prune: "true"
+  labels:
+    name: example-ns
+    some-label: some-value
+  name: example-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    some-annotation: some-value
+  name: example
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: kube-applier
+  namespace: example-ns
+`),
+			secretsData: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: example
+  namespace: example-ns
+stringData:
+  some-key: some-value
+  some-other-key: some-other-value
+---
+apiVersion: v1
+data:
+  some-value: c2Vuc2l0aXZlCg==
+kind: Secret
+metadata:
+  name: example-1
+  namespace: example-ns
+type: Opaque
+`),
+		},
+		{
+			yamlData: []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    kube-applier.io/dry-run: "false"
+    kube-applier.io/enabled: "true"
+    kube-applier.io/prune: "true"
+  labels:
+    name: example-ns
+    some-label: some-value
+  name: example-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    some-annotation: some-value
+  name: example 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: kube-applier
+  namespace: example-ns 
+`),
+			resourcesData: []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    kube-applier.io/dry-run: "false"
+    kube-applier.io/enabled: "true"
+    kube-applier.io/prune: "true"
+  labels:
+    name: example-ns
+    some-label: some-value
+  name: example-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    some-annotation: some-value
+  name: example
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: kube-applier
+  namespace: example-ns
+`),
+			secretsData: []byte{},
+		},
+		{
+			yamlData: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: example 
+  namespace: example-ns
+stringData:
+  some-key: some-value
+  some-other-key: some-other-value
+---
+apiVersion: v1
+data:
+  some-value: c2Vuc2l0aXZlCg==
+kind: Secret
+metadata:
+  name: example-1 
+  namespace: example-ns
+type: Opaque
+`),
+			resourcesData: []byte{},
+			secretsData: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: example
+  namespace: example-ns
+stringData:
+  some-key: some-value
+  some-other-key: some-other-value
+---
+apiVersion: v1
+data:
+  some-value: c2Vuc2l0aXZlCg==
+kind: Secret
+metadata:
+  name: example-1
+  namespace: example-ns
+type: Opaque
+`),
+		},
+		{
+			yamlData:      []byte{},
+			resourcesData: []byte{},
+			secretsData:   []byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		resources, secrets, err := splitSecrets(tc.yamlData)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+
+		if diff := deep.Equal(string(resources), string(tc.resourcesData)); diff != nil {
+			t.Error(diff)
+		}
+
+		if diff := deep.Equal(string(secrets), string(tc.secretsData)); diff != nil {
+			t.Error(diff)
+		}
+	}
+}

--- a/kubectl/client_test.go
+++ b/kubectl/client_test.go
@@ -94,6 +94,15 @@ The request is invalid: patch: Invalid value: "map[data:map[invalid:map[]] metad
 			t.Error(diff)
 		}
 	}
+
+	for _, term := range omitErrOutputTerms {
+		want := omitErrOutputMessage
+		got := filterErrOutput(term)
+
+		if diff := deep.Equal(got, want); diff != nil {
+			t.Error(diff)
+		}
+	}
 }
 
 func TestPruneArgs(t *testing.T) {

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -121,7 +121,6 @@ func (a *BatchApplier) Apply(applyList []string, options *ApplyOptions) ([]Apply
 			successes = append(successes, appliedFile)
 			log.Logger.Info(fmt.Sprintf("%v\n%v", cmd, output))
 		} else {
-			appliedFile.Output = "Apply output omitted on error in case of sensitive data\n"
 			appliedFile.ErrorMessage = err.Error()
 			failures = append(failures, appliedFile)
 			log.Logger.Warn(fmt.Sprintf("%v\n%v", cmd, appliedFile.ErrorMessage))

--- a/run/batch_applier_test.go
+++ b/run/batch_applier_test.go
@@ -126,9 +126,9 @@ func TestBatchApplierApplyFail(t *testing.T) {
 		expectFailureMetric("file3", metrics),
 	)
 	failures := []ApplyAttempt{
-		{"file1", "cmd file1", "Apply output omitted on error in case of sensitive data\n", "error file1"},
-		{"file2", "cmd file2", "Apply output omitted on error in case of sensitive data\n", "error file2"},
-		{"file3", "cmd file3", "Apply output omitted on error in case of sensitive data\n", "error file3"},
+		{"file1", "cmd file1", "output file1", "error file1"},
+		{"file2", "cmd file2", "output file2", "error file2"},
+		{"file3", "cmd file3", "output file3", "error file3"},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -174,8 +174,8 @@ func TestBatchApplierApplyPartial(t *testing.T) {
 		{"file3", "cmd file3", "output file3", ""},
 	}
 	failures := []ApplyAttempt{
-		{"file2", "cmd file2", "Apply output omitted on error in case of sensitive data\n", "error file2"},
-		{"file4", "cmd file4", "Apply output omitted on error in case of sensitive data\n", "error file4"},
+		{"file2", "cmd file2", "output file2", "error file2"},
+		{"file4", "cmd file4", "output file4", "error file4"},
 	}
 	tc := batchTestCase{
 		BatchApplier{


### PR DESCRIPTION
It's possible for the error output of kubectl to leak secrets. Initially
we addressed this by dropping all error output. This commit attempts to
readdress this in a more nuanced way.

For kustomize we can extract secrets from the YAML, apply that
separately and then drop only that output on error. This gives us 100%
confidence that we won't leak secrets.

For the other mode, where we apply manifests with `kubectl apply -f <path>`, 
this adds filtering that will squash output that contains
the terms `Secret` or `base64`. This addresses all instances of this
leak that we're aware of but could potentially leak exceptions.

Errors will continue to be omitted from logs, which covers us against
one of these theorectical exceptions being persisted through log
aggregation.