### PR TITLE
Skip applying directories without changes

### DIFF
--- a/git/gitutil.go
+++ b/git/gitutil.go
@@ -11,6 +11,7 @@ import (
 type UtilInterface interface {
 	HeadCommitLogForPaths(args ...string) (string, error)
 	HeadHashForPaths(args ...string) (string, error)
+	HasChangesForPath(path, sinceHash string) (bool, error)
 }
 
 // Util allows for fetching information about a Git repository using Git CLI
@@ -35,6 +36,17 @@ func (g *Util) HeadCommitLogForPaths(args ...string) (string, error) {
 	cmd = append(cmd, args...)
 	log, err := runGitCmd(g.RepoPath, cmd...)
 	return log, err
+}
+
+// HasChangesForPath returns true if changes have been committed since the
+// commit hash provided, under the specified path.
+func (g *Util) HasChangesForPath(path, sinceHash string) (bool, error) {
+	cmd := []string{"diff", "--quiet", sinceHash, "HEAD", "--", path}
+	_, err := runGitCmd(g.RepoPath, cmd...)
+	if _, ok := err.(*exec.ExitError); ok {
+		return true, nil
+	}
+	return false, err
 }
 
 func runGitCmd(dir string, args ...string) (string, error) {

--- a/git/mock_gitutil.go
+++ b/git/mock_gitutil.go
@@ -34,6 +34,7 @@ func (m *MockUtilInterface) EXPECT() *MockUtilInterfaceMockRecorder {
 
 // HeadCommitLogForPaths mocks base method
 func (m *MockUtilInterface) HeadCommitLogForPaths(args ...string) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range args {
 		varargs = append(varargs, a)
@@ -46,11 +47,13 @@ func (m *MockUtilInterface) HeadCommitLogForPaths(args ...string) (string, error
 
 // HeadCommitLogForPaths indicates an expected call of HeadCommitLogForPaths
 func (mr *MockUtilInterfaceMockRecorder) HeadCommitLogForPaths(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadCommitLogForPaths", reflect.TypeOf((*MockUtilInterface)(nil).HeadCommitLogForPaths), args...)
 }
 
 // HeadHashForPaths mocks base method
 func (m *MockUtilInterface) HeadHashForPaths(args ...string) (string, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range args {
 		varargs = append(varargs, a)
@@ -63,5 +66,21 @@ func (m *MockUtilInterface) HeadHashForPaths(args ...string) (string, error) {
 
 // HeadHashForPaths indicates an expected call of HeadHashForPaths
 func (mr *MockUtilInterfaceMockRecorder) HeadHashForPaths(args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadHashForPaths", reflect.TypeOf((*MockUtilInterface)(nil).HeadHashForPaths), args...)
+}
+
+// HasChangesForPath mocks base method
+func (m *MockUtilInterface) HasChangesForPath(path, sinceHash string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasChangesForPath", path, sinceHash)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasChangesForPath indicates an expected call of HasChangesForPath
+func (mr *MockUtilInterfaceMockRecorder) HasChangesForPath(path, sinceHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasChangesForPath", reflect.TypeOf((*MockUtilInterface)(nil).HasChangesForPath), path, sinceHash)
 }

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 
 	// Webserver and scheduler send run requests to runQueue channel, runner receives the requests and initiates runs.
 	// Only 1 pending request may sit in the queue at a time.
-	runQueue := make(chan run.Type, 1)
+	runQueue := make(chan run.Request, 1)
 
 	// Runner sends run results to runResults channel, webserver receives the results and displays them.
 	// Limit of 5 is arbitrary - there is significant delay between sends, and receives are handled near instantaneously.

--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func main() {
 
 	// Webserver and scheduler send run requests to runQueue channel, runner receives the requests and initiates runs.
 	// Only 1 pending request may sit in the queue at a time.
-	runQueue := make(chan bool, 1)
+	runQueue := make(chan run.Type, 1)
 
 	// Runner sends run results to runResults channel, webserver receives the results and displays them.
 	// Limit of 5 is arbitrary - there is significant delay between sends, and receives are handled near instantaneously.

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -24,6 +24,7 @@ type ApplyAttempt struct {
 	Command      string
 	Output       string
 	ErrorMessage string
+	Run          Info
 }
 
 // BatchApplierInterface allows for mocking out the functionality of BatchApplier when testing the full process of an apply run.
@@ -170,13 +171,16 @@ func (a *BatchApplier) apply(path string, options *ApplyOptions) (*ApplyAttempt,
 		dryRunStrategy = "server"
 	}
 
-	var cmd, output string
-	cmd, output, err = a.KubectlClient.Apply(path, ns, dryRunStrategy, kustomize, pruneWhitelist)
-	appliedFile := ApplyAttempt{path, cmd, output, ""}
+	cmd, output, err := a.KubectlClient.Apply(path, ns, dryRunStrategy, kustomize, pruneWhitelist)
+	appliedFile := ApplyAttempt{
+		FilePath:     path,
+		Command:      cmd,
+		Output:       output,
+		ErrorMessage: "",
+	}
 	if err != nil {
 		appliedFile.ErrorMessage = err.Error()
 	}
-
 	return &appliedFile, err == nil
 }
 

--- a/run/batch_applier.go
+++ b/run/batch_applier.go
@@ -50,11 +50,17 @@ type ApplyOptions struct {
 // Apply takes a list of files and attempts an apply command on each.
 // It returns two lists of ApplyAttempts - one for files that succeeded, and one for files that failed.
 func (a *BatchApplier) Apply(applyList []string, options *ApplyOptions) ([]ApplyAttempt, []ApplyAttempt) {
+	successes := []ApplyAttempt{}
+	failures := []ApplyAttempt{}
+
+	if len(applyList) == 0 {
+		return successes, failures
+	}
+
 	if a.WorkerCount == 0 {
 		a.WorkerCount = defaultBatchApplierWorkerCount
 	}
-	successes := []ApplyAttempt{}
-	failures := []ApplyAttempt{}
+
 	wg := sync.WaitGroup{}
 	mutex := sync.Mutex{}
 

--- a/run/batch_applier_test.go
+++ b/run/batch_applier_test.go
@@ -89,9 +89,9 @@ func TestBatchApplierApplySuccess(t *testing.T) {
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
-		{"file3", "cmd file3", "output file3", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
+		{"file3", "cmd file3", "output file3", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -134,9 +134,9 @@ func TestBatchApplierApplyFail(t *testing.T) {
 		expectFailureMetric("file3", metrics),
 	)
 	failures := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", "error file1"},
-		{"file2", "cmd file2", "output file2", "error file2"},
-		{"file3", "cmd file3", "output file3", "error file3"},
+		{"file1", "cmd file1", "output file1", "error file1", Info{}},
+		{"file2", "cmd file2", "output file2", "error file2", Info{}},
+		{"file3", "cmd file3", "output file3", "error file3", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -184,12 +184,12 @@ func TestBatchApplierApplyPartial(t *testing.T) {
 		expectFailureMetric("file4", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file3", "cmd file3", "output file3", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file3", "cmd file3", "output file3", "", Info{}},
 	}
 	failures := []ApplyAttempt{
-		{"file2", "cmd file2", "output file2", "error file2"},
-		{"file4", "cmd file4", "output file4", "error file4"},
+		{"file2", "cmd file2", "output file2", "error file2", Info{}},
+		{"file4", "cmd file4", "output file4", "error file4", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -233,9 +233,9 @@ func TestBatchApplierApplySuccessDryRun(t *testing.T) {
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
-		{"file3", "cmd file3", "output file3", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
+		{"file3", "cmd file3", "output file3", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -279,9 +279,9 @@ func TestBatchApplierApplySuccessDryRunNamespaces(t *testing.T) {
 		expectSuccessMetric("repo/file3", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"repo/file1", "cmd repo/file1", "output repo/file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
-		{"repo/file3", "cmd repo/file3", "output repo/file3", ""},
+		{"repo/file1", "cmd repo/file1", "output repo/file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
+		{"repo/file3", "cmd repo/file3", "output repo/file3", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -325,9 +325,9 @@ func TestBatchApplierApplySuccessDryRunAndDryRunNamespaces(t *testing.T) {
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
-		{"file3", "cmd file3", "output file3", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
+		{"file3", "cmd file3", "output file3", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -367,7 +367,7 @@ func TestBatchApplierApplyDisabledNamespaces(t *testing.T) {
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "false"}, "file3", kubeClient),
 	)
 	successes := []ApplyAttempt{
-		{"file2", "cmd file2", "output file2", ""},
+		{"file2", "cmd file2", "output file2", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -407,7 +407,7 @@ func TestBatchApplierApplyInvalidAnnotation(t *testing.T) {
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "unsupportedOption"}, "file3", kubeClient),
 	)
 	successes := []ApplyAttempt{
-		{"file2", "cmd file2", "output file2", ""},
+		{"file2", "cmd file2", "output file2", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -445,8 +445,8 @@ func TestBatchApplierApplySuccessPruneTrue(t *testing.T) {
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -479,7 +479,7 @@ func TestBatchApplierApplySuccessPruneClusterResources(t *testing.T) {
 		expectSuccessMetric("file1", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -517,8 +517,8 @@ func TestBatchApplierApplySuccessPruneFalse(t *testing.T) {
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{
@@ -564,8 +564,8 @@ func TestBatchApplierApplySuccessPruneBlacklist(t *testing.T) {
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
-		{"file1", "cmd file1", "output file1", ""},
-		{"file2", "cmd file2", "output file2", ""},
+		{"file1", "cmd file1", "output file1", "", Info{}},
+		{"file2", "cmd file2", "output file2", "", Info{}},
 	}
 	tc := batchTestCase{
 		BatchApplier{

--- a/run/result.go
+++ b/run/result.go
@@ -38,6 +38,11 @@ func (r *Result) TotalFiles() int {
 	return len(r.Successes) + len(r.Failures)
 }
 
+// Finished returns true if the Result is from a finished apply run.
+func (r *Result) Finished() bool {
+	return !r.Finish.IsZero()
+}
+
 // LastCommitLink returns a URL for the most recent commit if the envar $DIFF_URL_FORMAT is specified, otherwise it returns empty string.
 func (r *Result) LastCommitLink() string {
 	if r.CommitHash == "" || r.DiffURLFormat == "" || !strings.Contains(r.DiffURLFormat, "%s") {

--- a/run/result.go
+++ b/run/result.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 )
@@ -42,6 +43,11 @@ func (i Info) Latency() string {
 // Finished returns true if the Result is from a finished apply run.
 func (i Info) Finished() bool {
 	return !i.Finish.IsZero()
+}
+
+// Equal checks whether the Info struct is equal to another.
+func (i Info) Equal(info Info) bool {
+	return reflect.DeepEqual(i, info)
 }
 
 // LastCommitLink returns a URL for the most recent commit if the envar $DIFF_URL_FORMAT is specified, otherwise it returns empty string.

--- a/run/runner.go
+++ b/run/runner.go
@@ -107,7 +107,7 @@ func (r *Runner) run(t Type) (*Result, error) {
 	r.Metrics.UpdateRunLatency(r.Clock.Since(start).Seconds(), success)
 	r.Metrics.UpdateLastRunTimestamp(finish)
 
-	newRun := Result{start, finish, hash, commitLog, successes, failures, r.DiffURLFormat}
+	newRun := Result{start, finish, hash, commitLog, successes, failures, r.DiffURLFormat, t}
 	for _, s := range successes {
 		r.lastAppliedHash[s.FilePath] = hash
 	}

--- a/run/runner.go
+++ b/run/runner.go
@@ -15,6 +15,19 @@ import (
 // Type defines what kind of apply run is performed.
 type Type int
 
+func (t Type) String() string {
+	switch t {
+	case FullRun:
+		return "Full run"
+	case PartialRun:
+		return "Partial run"
+	case FailedRun:
+		return "Failed-only run"
+	default:
+		return "Unknown run type"
+	}
+}
+
 const (
 	// FullRun indicates a full apply run across all directories.
 	FullRun Type = iota

--- a/run/runner.go
+++ b/run/runner.go
@@ -81,7 +81,9 @@ func (r *Runner) Start() {
 			r.Errors <- err
 			return
 		}
-		r.RunResults <- *newRun
+		if newRun != nil {
+			r.RunResults <- *newRun
+		}
 	}
 }
 
@@ -113,7 +115,8 @@ func (r *Runner) run(t Request) (*Result, error) {
 				}
 			}
 			if !valid {
-				return nil, fmt.Errorf("Invalid path '%s'", t.Args.(string))
+				log.Logger.Error(fmt.Sprintf("Invalid path '%s' requested, ignoring", t.Args.(string)))
+				return nil, nil
 			}
 		}
 		dirs = d

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -13,7 +13,7 @@ type Scheduler struct {
 	PollInterval    time.Duration
 	FullRunInterval time.Duration
 	RepoPathFilters []string
-	RunQueue        chan<- Type
+	RunQueue        chan<- Request
 	Errors          chan<- error
 }
 
@@ -58,9 +58,9 @@ func (s *Scheduler) Start() {
 }
 
 // enqueue attempts to add a run to the queue, logging the result of the request.
-func (s *Scheduler) enqueue(runQueue chan<- Type, t Type) {
+func (s *Scheduler) enqueue(runQueue chan<- Request, t Type) {
 	select {
-	case runQueue <- t:
+	case runQueue <- Request{Type: t}:
 		log.Logger.Info("Run queued")
 	default:
 		log.Logger.Info("Run queue is already full")

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,27 +1,40 @@
 // On button click, sends empty POST request to API endpoint for forcing a run and shows a relevant alert when a response is received.
 $(document).ready(function() {
-    $('#force-button').bind('click', function(){
-        // Disable the button and close existing alert
-        $('#force-button').prop('disabled', true);
+    $('#force-full-button').bind('click', function(){
+        // Disable the buttons and close existing alert
+        $('.force-button').each(function(){ $(this).prop('disabled', true); });
         $('#force-alert').alert('close')
 
-        url =  window.location.href + 'api/v1/forceRun';
-        $.ajax({
-            type: 'POST',
-            url: url,
-            data: {},
-            dataType: "json",
-            success:function(data) {
-                showForceAlert(true, data.message)
-                $('#force-button').prop('disabled', false);
-            },
-            error:function() {
-                showForceAlert(false, 'Server error attempting to force a run. See container logs for more info.')
-                $('#force-button').prop('disabled', false);
-            }
-        });
+        forceRun(false)
+    });
+
+    $('#force-failed-button').bind('click', function(){
+        // Disable the buttons and close existing alert
+        $('.force-button').each(function(){ $(this).prop('disabled', true); });
+        $('#force-alert').alert('close')
+
+        forceRun(true)
     });
 });
+
+// Send an XHR request to the server to force a run.
+function forceRun(failed) {
+    url =  window.location.href + 'api/v1/forceRun';
+    $.ajax({
+        type: 'POST',
+        url: url,
+        data: {failed: failed},
+        dataType: "json",
+        success:function(data) {
+            showForceAlert(true, data.message)
+            $('.force-button').each(function(){ $(this).prop('disabled', false); });
+        },
+        error:function() {
+            showForceAlert(false, 'Server error attempting to force a run. See container logs for more info.')
+            $('.force-button').each(function(){ $(this).prop('disabled', false); });
+        }
+    });
+}
 
 // Show a relevant alert message, styled based on the "success" of the associated response.
 function showForceAlert(success, message) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
         $('.force-button').each(function(){ $(this).prop('disabled', true); });
         $('#force-alert').alert('close')
 
-        forceRun(false)
+        forceRun(false, '')
     });
 
     $('#force-failed-button').bind('click', function(){
@@ -13,17 +13,27 @@ $(document).ready(function() {
         $('.force-button').each(function(){ $(this).prop('disabled', true); });
         $('#force-alert').alert('close')
 
-        forceRun(true)
+        forceRun(true, '')
+    });
+
+    $(".force-namespace-button").each(function(){
+        $(this).bind('click', function(){
+            // Disable the buttons and close existing alert
+            $('.force-button').each(function(){ $(this).prop('disabled', true); });
+            $('#force-alert').alert('close')
+
+            forceRun(false, $(this).data('path'))
+        });
     });
 });
 
 // Send an XHR request to the server to force a run.
-function forceRun(failed) {
+function forceRun(failed, path) {
     url =  window.location.href + 'api/v1/forceRun';
     $.ajax({
         type: 'POST',
         url: url,
-        data: {failed: failed},
+        data: {failed: failed, path: path},
         dataType: "json",
         success:function(data) {
             showForceAlert(true, data.message)

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -11,6 +11,6 @@ pre.commit {
 	background-color: #f9f9f9;
 }
 
-#force-button {
+.force-button-group {
 	margin-bottom: 5px;
 }

--- a/sysutil/mock_clock.go
+++ b/sysutil/mock_clock.go
@@ -35,6 +35,7 @@ func (m *MockClockInterface) EXPECT() *MockClockInterfaceMockRecorder {
 
 // Now mocks base method
 func (m *MockClockInterface) Now() time.Time {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Now")
 	ret0, _ := ret[0].(time.Time)
 	return ret0
@@ -42,11 +43,13 @@ func (m *MockClockInterface) Now() time.Time {
 
 // Now indicates an expected call of Now
 func (mr *MockClockInterfaceMockRecorder) Now() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Now", reflect.TypeOf((*MockClockInterface)(nil).Now))
 }
 
 // Since mocks base method
 func (m *MockClockInterface) Since(arg0 time.Time) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Since", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -54,15 +57,18 @@ func (m *MockClockInterface) Since(arg0 time.Time) time.Duration {
 
 // Since indicates an expected call of Since
 func (mr *MockClockInterfaceMockRecorder) Since(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Since", reflect.TypeOf((*MockClockInterface)(nil).Since), arg0)
 }
 
 // Sleep mocks base method
 func (m *MockClockInterface) Sleep(arg0 time.Duration) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Sleep", arg0)
 }
 
 // Sleep indicates an expected call of Sleep
 func (mr *MockClockInterfaceMockRecorder) Sleep(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleep", reflect.TypeOf((*MockClockInterface)(nil).Sleep), arg0)
 }

--- a/templates/status.html
+++ b/templates/status.html
@@ -32,6 +32,7 @@
                     <h3 class="panel-title">Last Run</h3>
                 </div>
                 <div class="panel-body">
+                    <strong>Type: {{ .Type.String }}</strong><br>
                     <strong>Started: {{ .FormattedStart }}</strong><br>
                     <strong>Finished: {{ .FormattedFinish }}</strong><br>
                     <strong>Latency: {{ .Latency }}</strong><br>

--- a/templates/status.html
+++ b/templates/status.html
@@ -11,7 +11,7 @@
 </head>
 <body>
     <h1 class="text-center">kube-applier</h1>
-    {{ if .TotalFiles }}
+    {{ if .Finished }}
     <div class="row">
         <div class="text-center"><button id="force-button" class="btn btn-warning btn-s"><strong>Force Run</strong></button></div>
     </div>

--- a/templates/status.html
+++ b/templates/status.html
@@ -13,7 +13,12 @@
     <h1 class="text-center">kube-applier</h1>
     {{ if .Finished }}
     <div class="row">
-        <div class="text-center"><button id="force-button" class="btn btn-warning btn-s"><strong>Force Run</strong></button></div>
+        <div class="text-center">
+            <div class="force-button-group btn-group">
+                <button id="force-full-button" class="force-button btn btn-warning btn-s"><strong>Force full run</strong></button>
+                <button id="force-failed-button" class="force-button btn btn-warning btn-s"><strong>Force failed-only run</strong></button>
+            </div>
+        </div>
     </div>
     <div class="row">
         <div class="col-md-4"></div>

--- a/templates/status.html
+++ b/templates/status.html
@@ -15,8 +15,8 @@
     <div class="row">
         <div class="text-center">
             <div class="force-button-group btn-group">
-                <button id="force-full-button" class="force-button btn btn-warning btn-s"><strong>Force full run</strong></button>
-                <button id="force-failed-button" class="force-button btn btn-warning btn-s"><strong>Force failed-only run</strong></button>
+                <button id="force-full-button" class="force-button btn btn-warning btn-s"><strong>Force full apply run</strong></button>
+                {{ if .Failures }}<button id="force-failed-button" class="force-button btn btn-warning btn-s"><strong>Force failed-only run</strong></button>{{ end }}
             </div>
         </div>
     </div>
@@ -65,7 +65,7 @@
                                     <li class="list-group-item">
                                         <div class="row">
                                             <div class="col-md-10"><pre>{{ $file.Run.Type.String }} at commit <a href="{{ $file.Run.LastCommitLink }}">{{ $file.Run.CommitHash }}</a> started at {{ $file.Run.FormattedStart }}</pre></div>
-                                            <div class="col-md-2"><button data-path="{{ $file.FilePath }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply</strong></button></div>
+                                            <div class="col-md-2"><button data-path="{{ $file.FilePath }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
                                         </div>
                                     </li>
                                     <li class="list-group-item">

--- a/templates/status.html
+++ b/templates/status.html
@@ -11,7 +11,7 @@
 </head>
 <body>
     <h1 class="text-center">kube-applier</h1>
-    {{ if .Finished }}
+    {{ if .LastRun.Finished }}
     <div class="row">
         <div class="text-center">
             <div class="force-button-group btn-group">
@@ -32,12 +32,12 @@
                     <h3 class="panel-title">Last Run</h3>
                 </div>
                 <div class="panel-body">
-                    <strong>Type: {{ .Type.String }}</strong><br>
-                    <strong>Started: {{ .FormattedStart }}</strong><br>
-                    <strong>Finished: {{ .FormattedFinish }}</strong><br>
-                    <strong>Latency: {{ .Latency }}</strong><br>
-                    <strong>Last Commit {{ if .LastCommitLink }}<a href="{{ .LastCommitLink }}">(see diff)</a>{{ end }}</strong>
-                    <p><pre class="commit">{{ .FullCommit }}</pre></p>
+                    <strong>Type: {{ .LastRun.Type.String }}</strong><br>
+                    <strong>Started: {{ .LastRun.FormattedStart }}</strong><br>
+                    <strong>Finished: {{ .LastRun.FormattedFinish }}</strong><br>
+                    <strong>Latency: {{ .LastRun.Latency }}</strong><br>
+                    <strong>Last Commit {{ if .LastRun.LastCommitLink }}<a href="{{ .LastRun.LastCommitLink }}">(see diff)</a>{{ end }}</strong>
+                    <p><pre class="commit">{{ .LastRun.FullCommit }}</pre></p>
                 </div>
             </div>
         </div>
@@ -62,6 +62,12 @@
                             </div>
                             <div id="failure-{{$i}}" class="panel-collapse collapse">
                                 <ul class="list-group">
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-md-10"><pre>{{ $file.Run.Type.String }} at commit <a href="{{ $file.Run.LastCommitLink }}">{{ $file.Run.CommitHash }}</a> started at {{ $file.Run.FormattedStart }}</pre></div>
+                                            <div class="col-md-2"><button data-path="{{ $file.FilePath }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply</strong></button></div>
+                                        </div>
+                                    </li>
                                     <li class="list-group-item">
                                         <pre class="file-output">{{ printf "$ %s\n" $file.Command }}{{ $file.Output }}{{ $file.ErrorMessage }}</pre>
                                     </li>
@@ -89,11 +95,17 @@
                         <div class="panel">
                             <div class="panel-heading">
                                 <div class="panel-title">
-                                    {{ $file.FilePath }}
+                                    <a data-toggle="collapse" href="#success-{{$i}}">{{ $file.FilePath }}</a>
                                 </div>
                             </div>
-                            <div class="panel-collapse">
+                            <div id="success-{{$i}}" class="panel-collapse collapse">
                                 <ul class="list-group">
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-md-10"><pre>{{ $file.Run.Type.String }} at commit <a href="{{ $file.Run.LastCommitLink }}">{{ $file.Run.CommitHash }}</a> started at {{ $file.Run.FormattedStart }}</pre></div>
+                                            <div class="col-md-2"><button data-path="{{ $file.FilePath }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply</strong></button></div>
+                                        </div>
+                                    </li>
                                     <li class="list-group-item">
                                         <pre class="file-output">{{ printf "$ %s\n" $file.Command }}{{ $file.Output }}</pre>
                                     </li>

--- a/templates/status.html
+++ b/templates/status.html
@@ -60,7 +60,7 @@
                                     <a data-toggle="collapse" href="#failure-{{$i}}">{{ $file.FilePath }}</a>
                                 </div>
                             </div>
-                            <div id="failure-{{$i}}" class="panel-collapse collapse">
+                            <div id="failure-{{$i}}" class="panel-collapse">
                                 <ul class="list-group">
                                     <li class="list-group-item">
                                         <div class="row">
@@ -98,7 +98,7 @@
                                     <a data-toggle="collapse" href="#success-{{$i}}">{{ $file.FilePath }}</a>
                                 </div>
                             </div>
-                            <div id="success-{{$i}}" class="panel-collapse collapse">
+                            <div id="success-{{$i}}" class="panel-collapse {{ if not ($.LastRun.Equal $file.Run) }}collapse{{ end }}">
                                 <ul class="list-group">
                                     <li class="list-group-item">
                                         <div class="row">

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -40,8 +40,8 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.Template.Execute(w, s.Data); err != nil {
-		http.Error(w, "Error: Unable to load HTML template", http.StatusInternalServerError)
-		log.Logger.Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String())
+		http.Error(w, "Error: Unable to render HTML template", http.StatusInternalServerError)
+		log.Logger.Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String(), "err", err)
 		return
 	}
 	log.Logger.Info("Request completed successfully", "time", s.Clock.Now().String())

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -62,8 +62,14 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
+		runType := run.FullRun
+		if err := r.ParseForm(); err != nil {
+			log.Logger.Error("Could not parse form data, assuming full run.")
+		} else if r.FormValue("failed") == "true" {
+			runType = run.FailedRun
+		}
 		select {
-		case f.RunQueue <- run.FullRun:
+		case f.RunQueue <- runType:
 			log.Logger.Info("Run queued")
 		default:
 			log.Logger.Info("Run queue is already full")

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -19,7 +19,7 @@ const serverTemplatePath = "templates/status.html"
 type WebServer struct {
 	ListenPort int
 	Clock      sysutil.ClockInterface
-	RunQueue   chan<- bool
+	RunQueue   chan<- run.Type
 	RunResults <-chan run.Result
 	Errors     chan<- error
 }
@@ -49,7 +49,7 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // ForceRunHandler implements the http.Handle interface and serves an API endpoint for forcing a new run.
 type ForceRunHandler struct {
-	RunQueue chan<- bool
+	RunQueue chan<- run.Type
 }
 
 // ServeHTTP handles requests for forcing a run by attempting to add to the runQueue, and writes a response including the result and a relevant message.
@@ -63,7 +63,7 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case "POST":
 		select {
-		case f.RunQueue <- true:
+		case f.RunQueue <- run.FullRun:
 			log.Logger.Info("Run queued")
 		default:
 			log.Logger.Info("Run queue is already full")

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -114,7 +114,11 @@ func (ws *WebServer) Start() {
 
 	go func() {
 		for result := range ws.RunResults {
-			*lastRun = result
+			if result.Type == run.FullRun {
+				*lastRun = result
+			} else {
+				lastRun.Patch(result)
+			}
 		}
 	}()
 

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/utilitywarehouse/kube-applier/log"
+	"github.com/utilitywarehouse/kube-applier/run"
 	"github.com/utilitywarehouse/kube-applier/sysutil"
 
 	"github.com/golang/mock/gomock"
@@ -121,7 +122,7 @@ func TestStatusPageHandlerServeHTTP(t *testing.T) {
 
 //**** Tests for Force Run Handler ****
 func TestForceRunHandlerServeHTTP(t *testing.T) {
-	runQueue := make(chan bool, 1)
+	runQueue := make(chan run.Type, 1)
 	handler := ForceRunHandler{
 		runQueue,
 	}

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -122,7 +122,7 @@ func TestStatusPageHandlerServeHTTP(t *testing.T) {
 
 //**** Tests for Force Run Handler ****
 func TestForceRunHandlerServeHTTP(t *testing.T) {
-	runQueue := make(chan run.Type, 1)
+	runQueue := make(chan run.Request, 1)
 	handler := ForceRunHandler{
 		runQueue,
 	}


### PR DESCRIPTION
There's actually "a few" more changes bundled with this:
- multiple run “types”:
  - full (original flavour, triggered on schedule and manually)
   - partial (git diff based triggered by polling)
   - failed-only (triggered manually, only directories that failed during the last run)
   - single-dir (triggered manually)
- ui improvements:
  - collapse all namespaces except for failures and the ones applied during the last run
  - new button to force run a single namespace
  - each namespace also displays info on when it was last applied
