### PR TITLE
Revisit the run type names and string description

### DIFF
--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -30,7 +30,7 @@ func (s *Scheduler) Start() {
 				select {
 				case <-fullRunTickerChan:
 					log.Logger.Info("Full run interval reached, queueing run", "interval", s.FullRunInterval)
-					s.enqueue(s.RunQueue, FullRun)
+					s.enqueue(s.RunQueue, ScheduledFullRun)
 				}
 			}
 		}()

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -62,13 +62,13 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
-		runRequest := run.Request{Type: run.FullRun}
+		runRequest := run.Request{Type: run.ForcedFullRun}
 		if err := r.ParseForm(); err != nil {
 			log.Logger.Error("Could not parse form data, assuming full run.")
 		} else if r.FormValue("failed") == "true" {
-			runRequest.Type = run.FailedRun
+			runRequest.Type = run.FailedOnlyRun
 		} else if v := r.FormValue("path"); v != "" {
-			runRequest.Type = run.DirectoryRun
+			runRequest.Type = run.SingleDirectoryRun
 			runRequest.Args = v
 		}
 		select {
@@ -123,11 +123,7 @@ func (ws *WebServer) Start() {
 
 	go func() {
 		for result := range ws.RunResults {
-			if result.LastRun.Type == run.FullRun {
-				*lastRun = result
-			} else {
-				lastRun.Patch(result)
-			}
+			lastRun.Patch(result)
 		}
 	}()
 


### PR DESCRIPTION
Differentiate between a scheduled and a full failed run. Rename some of
the types and change their descriptions so that they convey more meaning
on the web ui.