### PR TITLE
Add support for --server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ metadata:
     kube-applier.io/dry-run: "false"
     kube-applier.io/prune: "true"
     kube-applier.io/prune-cluster-resources: "false"
+    kube-applier.io/server-side: "false"
 ```
 
 ### Mounting the Git Repository

--- a/kube/client.go
+++ b/kube/client.go
@@ -17,6 +17,7 @@ const (
 	dryRunAnnotation                = "kube-applier.io/dry-run"
 	pruneAnnotation                 = "kube-applier.io/prune"
 	pruneClusterResourcesAnnotation = "kube-applier.io/prune-cluster-resources"
+	serverSideAnnotation            = "kube-applier.io/server-side"
 )
 
 // KAAnnotations contains the standard set of annotations on the Namespace
@@ -26,6 +27,7 @@ type KAAnnotations struct {
 	DryRun                string
 	Prune                 string
 	PruneClusterResources string
+	ServerSide            string
 }
 
 // ClientInterface allows for mocking out the functionality of Client when testing the full process of an apply run.
@@ -74,6 +76,7 @@ func (c *Client) NamespaceAnnotations(namespace string) (KAAnnotations, error) {
 	kaa.DryRun = ns.Annotations[dryRunAnnotation]
 	kaa.Prune = ns.Annotations[pruneAnnotation]
 	kaa.PruneClusterResources = ns.Annotations[pruneClusterResourcesAnnotation]
+	kaa.ServerSide = ns.Annotations[serverSideAnnotation]
 
 	return kaa, nil
 }

--- a/kubectl/mock_client.go
+++ b/kubectl/mock_client.go
@@ -33,9 +33,9 @@ func (m *MockClientInterface) EXPECT() *MockClientInterfaceMockRecorder {
 }
 
 // Apply mocks base method
-func (m *MockClientInterface) Apply(path, namespace, dryRunStrategy string, kustomize bool, pruneWhitelist []string) (string, string, error) {
+func (m *MockClientInterface) Apply(path string, applyFlags ApplyFlags) (string, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", path, namespace, dryRunStrategy, kustomize, pruneWhitelist)
+	ret := m.ctrl.Call(m, "Apply", path, applyFlags)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -43,7 +43,7 @@ func (m *MockClientInterface) Apply(path, namespace, dryRunStrategy string, kust
 }
 
 // Apply indicates an expected call of Apply
-func (mr *MockClientInterfaceMockRecorder) Apply(path, namespace, dryRunStrategy, kustomize, pruneWhitelist interface{}) *gomock.Call {
+func (mr *MockClientInterfaceMockRecorder) Apply(path, applyFlags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClientInterface)(nil).Apply), path, namespace, dryRunStrategy, kustomize, pruneWhitelist)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockClientInterface)(nil).Apply), path, applyFlags)
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -11,7 +11,7 @@ import (
 	"github.com/utilitywarehouse/kube-applier/log"
 )
 
-var kubectlOutputPattern = regexp.MustCompile(`([\w.\-]+)\/([\w.\-:]+) (\w+).*`)
+var kubectlOutputPattern = regexp.MustCompile(`([\w.\-]+)\/([\w.\-:]+) ([\w-]+).*`)
 
 // PrometheusInterface allows for mocking out the functionality of Prometheus when testing the full process of an apply run.
 type PrometheusInterface interface {

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -98,3 +98,34 @@ secret/k8s-auth-conf unchanged (server dry run)
 		t.Error(diff)
 	}
 }
+
+func TestParseKubectlServerSideApply(t *testing.T) {
+	output := `namespace/namespaceName serverside-applied
+limitrange/limit-range serverside-applied
+role.rbac.authorization.k8s.io/auth serverside-applied
+rolebinding.rbac.authorization.k8s.io/rolebinding serverside-applied
+serviceaccount/account serverside-applied
+networkpolicy.networking.k8s.io/default serverside-applied
+clusterrole.rbac.authorization.k8s.io/system:metrics-server serverside-applied
+service/serviceName serverside-applied
+deployment.apps/deploymentName serverside-applied
+`
+
+	want := []Result{
+		{"namespace", "namespaceName", "serverside-applied"},
+		{"limitrange", "limit-range", "serverside-applied"},
+		{"role.rbac.authorization.k8s.io", "auth", "serverside-applied"},
+		{"rolebinding.rbac.authorization.k8s.io", "rolebinding", "serverside-applied"},
+		{"serviceaccount", "account", "serverside-applied"},
+		{"networkpolicy.networking.k8s.io", "default", "serverside-applied"},
+		{"clusterrole.rbac.authorization.k8s.io", "system:metrics-server", "serverside-applied"},
+		{"service", "serviceName", "serverside-applied"},
+		{"deployment.apps", "deploymentName", "serverside-applied"},
+	}
+
+	got := parseKubectlOutput(output)
+
+	if diff := deep.Equal(got, want); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/run/batch_applier_test.go
+++ b/run/batch_applier_test.go
@@ -85,17 +85,17 @@ func TestBatchApplierApplySuccess(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -132,17 +132,17 @@ func TestBatchApplierApplyFail(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnFailure("/repo/file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectFailureMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnFailure("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectFailureMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnFailure("/repo/file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectFailureMetric("file3", metrics),
 	)
 	failures := []ApplyAttempt{
@@ -179,22 +179,22 @@ func TestBatchApplierApplyPartial(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3", "file4"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnFailure("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectFailureMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file3", "file3", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file4", kubeClient),
-		expectApplyAndReturnFailure("/repo/file4", "file4", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnFailure("/repo/file4", kubectl.ApplyFlags{Namespace: "file4", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectFailureMetric("file4", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -235,17 +235,17 @@ func TestBatchApplierApplySuccessDryRun(t *testing.T) {
 
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -283,17 +283,17 @@ func TestBatchApplierApplySuccessDryRunNamespaces(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -331,17 +331,17 @@ func TestBatchApplierApplySuccessDryRunAndDryRunNamespaces(t *testing.T) {
 	applyList := []string{"file1", "file2", "file3"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", DryRun: "true"}, "file3", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file3", "file3", "server", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "server", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file3", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -382,7 +382,7 @@ func TestBatchApplierApplyDisabledNamespaces(t *testing.T) {
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
@@ -424,7 +424,7 @@ func TestBatchApplierApplyInvalidAnnotation(t *testing.T) {
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	gomock.InOrder(
@@ -462,12 +462,12 @@ func TestBatchApplierApplySuccessPruneTrue(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", Prune: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -503,7 +503,7 @@ func TestBatchApplierApplySuccessPruneClusterResources(t *testing.T) {
 	applyList := []string{"file1"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", PruneClusterResources: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", testAllResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testAllResources}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -538,12 +538,12 @@ func TestBatchApplierApplySuccessPruneFalse(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", Prune: "false"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", nil, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none"}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", testApplyOptions.NamespacedResources, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -587,12 +587,12 @@ func TestBatchApplierApplySuccessPruneBlacklist(t *testing.T) {
 	applyList := []string{"file1", "file2"}
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file1", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file1", "file1", "none", []string{"autoscaling/v1/HorizontalPodAutoscaler"}, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: []string{"autoscaling/v1/HorizontalPodAutoscaler"}}, kubectlClient),
 		expectSuccessMetric("file1", metrics),
 	)
 	gomock.InOrder(
 		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", PruneClusterResources: "true"}, "file2", kubeClient),
-		expectApplyAndReturnSuccess("/repo/file2", "file2", "none", []string{"autoscaling/v1/HorizontalPodAutoscaler", "core/v1/Namespace"}, kubectlClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: []string{"autoscaling/v1/HorizontalPodAutoscaler", "core/v1/Namespace"}}, kubectlClient),
 		expectSuccessMetric("file2", metrics),
 	)
 	successes := []ApplyAttempt{
@@ -617,12 +617,59 @@ func TestBatchApplierApplySuccessPruneBlacklist(t *testing.T) {
 	applyAndAssert(t, tc)
 }
 
-func expectApplyAndReturnSuccess(file, namespace, dryRunStrategy string, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
-	return kubectlClient.EXPECT().Apply(file, namespace, dryRunStrategy, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, nil)
+func TestBatchApplierApplySuccessServerSide(t *testing.T) {
+	log.InitLogger("info")
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	kubeClient := kube.NewMockClientInterface(mockCtrl)
+	kubectlClient := kubectl.NewMockClientInterface(mockCtrl)
+	metrics := metrics.NewMockPrometheusInterface(mockCtrl)
+
+	// All files succeed
+	applyList := []string{"file1", "file2", "file3"}
+	gomock.InOrder(
+		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", ServerSide: "false"}, "file1", kubeClient),
+		expectApplyAndReturnSuccess("/repo/file1", kubectl.ApplyFlags{Namespace: "file1", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
+		expectSuccessMetric("file1", metrics),
+	)
+	gomock.InOrder(
+		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true", ServerSide: "true"}, "file2", kubeClient),
+		expectApplyAndReturnSuccess("/repo/file2", kubectl.ApplyFlags{Namespace: "file2", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources, ServerSide: true}, kubectlClient),
+		expectSuccessMetric("file2", metrics),
+	)
+	gomock.InOrder(
+		expectNamespaceAnnotationsAndReturn(kube.KAAnnotations{Enabled: "true"}, "file3", kubeClient),
+		expectApplyAndReturnSuccess("/repo/file3", kubectl.ApplyFlags{Namespace: "file3", DryRunStrategy: "none", PruneWhitelist: testApplyOptions.NamespacedResources}, kubectlClient),
+		expectSuccessMetric("file3", metrics),
+	)
+	successes := []ApplyAttempt{
+		{"file1", "cmd /repo/file1", "output /repo/file1", "", Info{}, time.Time{}, time.Time{}},
+		{"file2", "cmd /repo/file2", "output /repo/file2", "", Info{}, time.Time{}, time.Time{}},
+		{"file3", "cmd /repo/file3", "output /repo/file3", "", Info{}, time.Time{}, time.Time{}},
+	}
+	tc := batchTestCase{
+		BatchApplier{
+			KubectlClient: kubectlClient,
+			KubeClient:    kubeClient,
+			Metrics:       metrics,
+			Clock:         &zeroClock{},
+		},
+		"/repo",
+		applyList,
+		testApplyOptions,
+		successes,
+		[]ApplyAttempt{},
+	}
+	applyAndAssert(t, tc)
 }
 
-func expectApplyAndReturnFailure(file, namespace, dryRunStrategy string, pruneWhitelist []string, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
-	return kubectlClient.EXPECT().Apply(file, namespace, dryRunStrategy, false, pruneWhitelist).Times(1).Return("cmd "+file, "output "+file, fmt.Errorf("error "+file))
+func expectApplyAndReturnSuccess(file string, applyFlags kubectl.ApplyFlags, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
+	return kubectlClient.EXPECT().Apply(file, applyFlags).Times(1).Return("cmd "+file, "output "+file, nil)
+}
+
+func expectApplyAndReturnFailure(file string, applyFlags kubectl.ApplyFlags, kubectlClient *kubectl.MockClientInterface) *gomock.Call {
+	return kubectlClient.EXPECT().Apply(file, applyFlags).Times(1).Return("cmd "+file, "output "+file, fmt.Errorf("error "+file))
 }
 
 func expectNamespaceAnnotationsAndReturn(ret kube.KAAnnotations, namespace string, kubeClient *kube.MockClientInterface) *gomock.Call {


### PR DESCRIPTION
Create an annotation that can toggle server-side apply on. Defaults to false, at least while this feature is still beta.

This increases the number of positional arguments to the point that I think it's worth creating a struct for passing optional flags to the apply command. So I've done that.

This also moves the inference of whether to do a kustomize apply into the kubectl package.