### PR TITLE
Set --force-conflicts with --server-side

### DIFF
--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -61,7 +61,7 @@ func (f *ApplyFlags) Args() []string {
 	}
 
 	if f.ServerSide {
-		args = append(args, "--server-side")
+		args = append(args, []string{"--server-side", "--force-conflicts"}...)
 	}
 
 	if len(f.PruneWhitelist) > 0 {

--- a/kubectl/client_test.go
+++ b/kubectl/client_test.go
@@ -123,6 +123,7 @@ func TestApplyFlagsArgs(t *testing.T) {
 			},
 			want: []string{"-n", "example", "--dry-run=server",
 				"--server-side",
+				"--force-conflicts",
 				"--prune", "--all",
 				"--prune-whitelist=core/v1/ConfigMap",
 				"--prune-whitelist=core/v1/Pod",


### PR DESCRIPTION
A conflict occurs when a server-side apply updates a field which is managed or co-managed by another 'field manager'. It causes kubectl to exit with status 1.

This could be useful for identifying instances where kube-applier is jostling with some other process for management of a resource but mostly I imagine this will be cases where someone has performed a manual client-side apply.

KA should be applying the source of truth for the resources it manages, so it seems right to me that it forcibly coerce things to match its perspective.