### PR TITLE
Optimize the repository git clone

### DIFF
--- a/git/gitutil.go
+++ b/git/gitutil.go
@@ -64,10 +64,22 @@ func (g *Util) SplitPath() (string, string, error) {
 	return strings.Trim(root, "\n"), strings.Trim(sub, "\n"), nil
 }
 
-// CloneRepository clones a local repository to a new location on disk.
-func CloneRepository(src, dst string) error {
-	_, err := runGitCmd("/", "clone", src, dst)
-	return err
+// CloneRepository clones a repository to a new location on disk. If paths are
+// provided then only those paths are checked out in the clone.
+func CloneRepository(src, dst string, paths ...string) error {
+	args := []string{"clone", src, dst}
+	if len(paths) > 0 {
+		args = append(args, "--no-checkout")
+	}
+	if _, err := runGitCmd("/", args...); err != nil {
+		return err
+	}
+	if len(paths) > 0 {
+		if _, err := runGitCmd(dst, append([]string{"checkout", "HEAD", "--"}, paths...)...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func runGitCmd(dir string, args ...string) (string, error) {

--- a/run/runner.go
+++ b/run/runner.go
@@ -102,16 +102,16 @@ func (r *Runner) run(t Request) (*Result, error) {
 	start := r.Clock.Now()
 	log.Logger.Info("Started apply run", "start-time", start)
 
-	gitUtil, cleanupTemp, err := r.copyRepository()
-	if err != nil {
-		return nil, err
-	}
-	defer cleanupTemp()
-
 	apps, err := r.KubeClient.ListApplications(context.TODO())
 	if err != nil {
 		log.Logger.Error("Could not list Applications: %v", err)
 	}
+
+	gitUtil, cleanupTemp, err := r.copyRepository(apps)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupTemp()
 
 	var appList []kubeapplierv1alpha1.Application
 	if t.Type == ScheduledFullRun || t.Type == ForcedFullRun {
@@ -248,7 +248,7 @@ func (r *Runner) pruneUnchangedDirs(gitUtil *git.Util, apps []kubeapplierv1alpha
 	return prunedApps
 }
 
-func (r *Runner) copyRepository() (*git.Util, func(), error) {
+func (r *Runner) copyRepository(apps []kubeapplierv1alpha1.Application) (*git.Util, func(), error) {
 	root, sub, err := (&git.Util{RepoPath: r.RepoPath}).SplitPath()
 	if err != nil {
 		return nil, nil, err
@@ -257,7 +257,11 @@ func (r *Runner) copyRepository() (*git.Util, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := git.CloneRepository(root, tmpDir); err != nil {
+	var paths []string
+	for _, a := range apps {
+		paths = append(paths, fmt.Sprintf("%s/%s", sub, a.Namespace))
+	}
+	if err := git.CloneRepository(root, tmpDir, paths...); err != nil {
 		return nil, nil, err
 	}
 	return &git.Util{RepoPath: path.Join(tmpDir, sub)}, func() { os.RemoveAll(tmpDir) }, nil

--- a/run/runner.go
+++ b/run/runner.go
@@ -259,7 +259,7 @@ func (r *Runner) copyRepository(apps []kubeapplierv1alpha1.Application) (*git.Ut
 	}
 	var paths []string
 	for _, a := range apps {
-		paths = append(paths, fmt.Sprintf("%s/%s", sub, a.Namespace))
+		paths = append(paths, fmt.Sprintf("%s/%s", sub, a.Spec.RepositoryPath))
 	}
 	if err := git.CloneRepository(root, tmpDir, paths...); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Cloning the whole of our kubernetes manifests repository was taking ~44s on my laptop. Doing a clone with `--no-checkout` and then only checking out the paths we have apps for under the sub path brings it down to ~2s.