### PR TITLE
Update kustomize to 3.8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --no-cache add git gcc musl-dev &&\
 
 FROM alpine:3.12
 ENV KUBECTL_VERSION v1.19.2
-ENV KUSTOMIZE_VERSION v3.8.4
+ENV KUSTOMIZE_VERSION v3.8.5
 COPY templates/ /templates/
 COPY static/ /static/
 RUN apk --no-cache add git openssh-client tini &&\


### PR DESCRIPTION
We noticed a bug in 3.8.4 when using a composed env var that contains another one. Example:

 env:
            - name: PROXIMO_PASSWORD
            - name: SOURCE_URL
              value: "proximo://finance:$(PROXIMO_PASSWORD)@billing-proximo.billing:6868/transaction-log-v3....
For this to work, in the final yaml, the PROXIMO_PASSWORD must appear before SOURCE_URL.
When using a generic base, in 3.8.4, if PROXIMO_PASSWORD was defined only in the concrete resource, and SOURCE_URL was defined in base, the PROXIMO_PASSWORD would appear after SOURCE_URL, making it not functional.
As a workaround, we had to put PROXIMO_PASSWORD in the base for this to work with 3.8.4, although it is not used everywhere:
Base: https://github.com/utilitywarehouse/finance-manifests/blob/master/finance-tx-log-stream-forwarder/app.yaml#L68
Concrete resources:

https://github.com/utilitywarehouse/kubernetes-manifests/blob/master/dev-aws/finance/account-debt-validation/filtered-forwarders/tx-log-stream-forwarder-billing-to-balance-api/app.yaml#L12
https://github.com/utilitywarehouse/kubernetes-manifests/blob/master/dev-aws/finance/account-debt-validation/filtered-forwarders/tx-log-stream-forwarder-dd-fabricated-to-balance-api/app.yaml#L12
Didn't test yet 3.8.6 that is latest kustomize version.