### PR TITLE
Rework metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ the Prometheus default metrics, the following custom metrics are included:
   that observes the number of times a run failed to queue properly, labelled
   with the namespace name and the run type.
 
+- **kube_applier_application_spec_dry_run** - A
+  [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
+  that captures the value of dryRun in the Application spec, labelled with the
+  namespace name.
+
+- **kube_applier_application_spec_run_interval** - A
+  [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
+  that captures the value of runInterval in the Application spec, labelled with
+  the namespace name.
+
 The Prometheus [HTTP API](https://prometheus.io/docs/querying/api/) (also see
 the [Go
 library](https://github.com/prometheus/client_golang/tree/master/api/prometheus))

--- a/README.md
+++ b/README.md
@@ -210,35 +210,34 @@ The HTML template for the status page lives in `templates/status.html`, and
 ### Metrics
 
 kube-applier uses [Prometheus](https://github.com/prometheus/client_golang) for
-metrics. Metrics are hosted on the webserver at /metrics (status UI is the
-index page). In addition to the Prometheus default metrics, the following
-custom metrics are included:
+metrics. Metrics are hosted on the webserver at `/__/metrics`. In addition to
+the Prometheus default metrics, the following custom metrics are included:
 
-- **run_latency_seconds** - A
-  [Summary](https://godoc.org/github.com/prometheus/client_golang/prometheus#Summary)
-  that keeps track of the durations of each apply run, tagged with a boolean for
-  whether or not the run was a success (i.e. no failed apply attempts).
+- **kube_applier_run_latency_seconds** - A
+  [Histogram](https://godoc.org/github.com/prometheus/client_golang/prometheus#Histogram)
+  that keeps track of the durations of each apply run, labelled with the
+  namespace name and a boolean for whether or not the run was successful.
 
-- **namespace_apply_count** - A
+- **kube_applier_namespace_apply_count** - A
   [Counter](https://godoc.org/github.com/prometheus/client_golang/prometheus#Counter)
   for each namespace that has had an apply attempt over the lifetime of the
-  container, incremented with each apply attempt and tagged by the namespace and
-  the result of the attempt.
+  container, incremented with each apply attempt and labelled by the namespace
+  and the result of the attempt.
 
-- **result_summary** - A
+- **kube_applier_result_summary** - A
   [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
-  for each deployment, labelled with the namespace, action, status and type of
-  object applied
+  for each resource, labelled with the namespace, action, status and type of
+  object applied.
 
-- **kubectl_exit_code_count** - A
+- **kube_applier_kubectl_exit_code_count** - A
   [Counter](https://godoc.org/github.com/prometheus/client_golang/prometheus#Counter)
   for each exit code returned by executions of `kubectl`, labelled with the
   namespace and exit code.
 
-- **last_run_timestamp_seconds** - A
+- **kube_applier_last_run_timestamp_seconds** - A
   [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
-  that reports the last time a run finished, expressed in seconds
-  since the Unix Epoch.
+  that reports the last time a run finished, expressed in seconds since the Unix
+  Epoch and labelled with the namespace name.
 
 The Prometheus [HTTP API](https://prometheus.io/docs/querying/api/) (also see
 the [Go

--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ the Prometheus default metrics, the following custom metrics are included:
   that reports the last time a run finished, expressed in seconds since the Unix
   Epoch and labelled with the namespace name.
 
+- **kube_applier_run_queue** - A
+  [Gauge](https://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
+  that reports the number of runs that are currently queued, labelled with the
+  namespace name and the run type.
+
+- **kube_applier_run_queue_failures** - A
+  [Counter](https://godoc.org/github.com/prometheus/client_golang/prometheus#Counter)
+  that observes the number of times a run failed to queue properly, labelled
+  with the namespace name and the run type.
+
 The Prometheus [HTTP API](https://prometheus.io/docs/querying/api/) (also see
 the [Go
 library](https://github.com/prometheus/client_golang/tree/master/api/prometheus))

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -33,7 +33,6 @@ var (
 type Client struct {
 	Host    string
 	Label   string
-	Metrics *metrics.Prometheus
 	Timeout time.Duration
 }
 
@@ -227,14 +226,14 @@ func (c *Client) apply(path string, stdin []byte, flags ApplyFlags) (string, str
 	out, err := kubectlCmd.CombinedOutput()
 	if err != nil {
 		if e, ok := err.(*exec.ExitError); ok {
-			c.Metrics.UpdateKubectlExitCodeCount(flags.Namespace, e.ExitCode())
+			metrics.UpdateKubectlExitCodeCount(flags.Namespace, e.ExitCode())
 		}
 		if ctx.Err() == context.DeadlineExceeded {
 			err = errors.Wrap(ctx.Err(), err.Error())
 		}
 		return kubectlCmd.String(), string(out), err
 	}
-	c.Metrics.UpdateKubectlExitCodeCount(flags.Namespace, 0)
+	metrics.UpdateKubectlExitCodeCount(flags.Namespace, 0)
 
 	return kubectlCmd.String(), string(out), nil
 }

--- a/main.go
+++ b/main.go
@@ -199,6 +199,7 @@ func main() {
 		ApplicationPollInterval: time.Duration(api) * time.Second,
 		GitPollInterval:         time.Duration(gpi) * time.Second,
 		KubeClient:              kubeClient,
+		Metrics:                 metrics,
 		RepoPath:                repoPath,
 		RunQueue:                runQueue,
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/utilitywarehouse/kube-applier/client"
 	"github.com/utilitywarehouse/kube-applier/kubectl"
 	"github.com/utilitywarehouse/kube-applier/log"
-	"github.com/utilitywarehouse/kube-applier/metrics"
 	"github.com/utilitywarehouse/kube-applier/run"
 	"github.com/utilitywarehouse/kube-applier/sysutil"
 	"github.com/utilitywarehouse/kube-applier/webserver"
@@ -140,9 +139,6 @@ func main() {
 
 	log.InitLogger(logLevel)
 
-	metrics := &metrics.Prometheus{}
-	metrics.Init()
-
 	clock := &sysutil.Clock{}
 
 	rt, _ := strconv.Atoi(repoTimeout)
@@ -163,7 +159,6 @@ func main() {
 		os.Exit(1)
 	}
 	kubectlClient := &kubectl.Client{
-		Metrics: metrics,
 		Timeout: execTimeoutDuration,
 	}
 
@@ -185,7 +180,6 @@ func main() {
 		DryRun:         dr,
 		KubeClient:     kubeClient,
 		KubectlClient:  kubectlClient,
-		Metrics:        metrics,
 		PruneBlacklist: pruneBlacklistSlice,
 		RepoPath:       repoPath,
 		WorkerCount:    runnerWorkerCount,
@@ -199,7 +193,6 @@ func main() {
 		ApplicationPollInterval: time.Duration(api) * time.Second,
 		GitPollInterval:         time.Duration(gpi) * time.Second,
 		KubeClient:              kubeClient,
-		Metrics:                 metrics,
 		RepoPath:                repoPath,
 		RunQueue:                runQueue,
 	}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -134,6 +134,20 @@ func AddRunRequestQueueFailure(t string, app *kubeapplierv1alpha1.Application) {
 	}).Inc()
 }
 
+// ReconcileLastRunTimestamps ensures that the last_run_timestamp metric
+// correctly represents the state in the cluster
+func ReconcileLastRunTimestamps(apps []kubeapplierv1alpha1.Application) {
+	lastRunTimestamp.Reset()
+	for _, app := range apps {
+		if app.Status.LastRun == nil {
+			continue
+		}
+		lastRunTimestamp.With(prometheus.Labels{
+			"namespace": app.Namespace,
+		}).Set(float64(app.Status.LastRun.Finished.Unix()))
+	}
+}
+
 // UpdateFromLastRun takes information from an Application's LastRun status and
 // updates all the relevant metrics
 func UpdateFromLastRun(app *kubeapplierv1alpha1.Application) {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -144,6 +144,15 @@ func UpdateResultSummary(apps []kubeapplierv1alpha1.Application) {
 	}
 }
 
+// Reset deletes all metrics. This is exported for use in integration tests.
+func Reset() {
+	kubectlExitCodeCount.Reset()
+	namespaceApplyCount.Reset()
+	runLatency.Reset()
+	resultSummary.Reset()
+	lastRunTimestamp.Reset()
+}
+
 type applyObjectResult struct {
 	Type, Name, Action string
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -8,8 +8,13 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/utilitywarehouse/kube-applier/log"
+)
+
+const (
+	metricsNamespace = "kube_applier"
 )
 
 var kubectlOutputPattern = regexp.MustCompile(`([\w.\-]+)\/([\w.\-:]+) ([\w-]+).*`)
@@ -28,9 +33,11 @@ type Prometheus struct {
 
 // Init creates and registers the custom metrics for kube-applier.
 func (p *Prometheus) Init() {
-	p.kubectlExitCodeCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "kubectl_exit_code_count",
-		Help: "Count of kubectl exit codes",
+	p.kubectlExitCodeCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runner",
+		Name:      "kubectl_exit_code_count",
+		Help:      "Count of kubectl exit codes",
 	},
 		[]string{
 			// Path of the file that was applied
@@ -39,9 +46,11 @@ func (p *Prometheus) Init() {
 			"exit_code",
 		},
 	)
-	p.namespaceApplyCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "namespace_apply_count",
-		Help: "Success metric for every namespace applied",
+	p.namespaceApplyCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runner",
+		Name:      "namespace_apply_count",
+		Help:      "Success metric for every namespace applied",
 	},
 		[]string{
 			// Path of the file that was applied
@@ -50,18 +59,22 @@ func (p *Prometheus) Init() {
 			"success",
 		},
 	)
-	p.runLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "run_latency_seconds",
-		Help: "Latency for completed apply runs",
+	p.runLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runner",
+		Name:      "run_latency_seconds",
+		Help:      "Latency for completed apply runs",
 	},
 		[]string{
 			// Result: true if the run was successful, false otherwise
 			"success",
 		},
 	)
-	p.resultSummary = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "result_summary",
-		Help: "Result summary for every manifest",
+	p.resultSummary = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runner",
+		Name:      "result_summary",
+		Help:      "Result summary for every manifest",
 	},
 		[]string{
 			// The object namespace
@@ -74,16 +87,12 @@ func (p *Prometheus) Init() {
 			"action",
 		},
 	)
-	p.lastRunTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_run_timestamp_seconds",
-		Help: "Timestamp of the last completed apply run",
+	p.lastRunTimestamp = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runner",
+		Name:      "last_run_timestamp_seconds",
+		Help:      "Timestamp of the last completed apply run",
 	})
-
-	prometheus.MustRegister(p.kubectlExitCodeCount)
-	prometheus.MustRegister(p.resultSummary)
-	prometheus.MustRegister(p.namespaceApplyCount)
-	prometheus.MustRegister(p.runLatency)
-	prometheus.MustRegister(p.lastRunTimestamp)
 }
 
 // UpdateKubectlExitCodeCount increments for each exit code returned by kubectl

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -26,7 +26,7 @@ service/serviceName unchanged
 deployment.apps/deploymentName unchanged
 `
 
-	want := []Result{
+	want := []applyObjectResult{
 		{"namespace", "namespaceName", "configured"},
 		{"limitrange", "limit-range", "configured"},
 		{"role.rbac.authorization.k8s.io", "auth", "unchanged"},
@@ -57,7 +57,7 @@ service/serviceName configured (server dry run)
 deployment.apps/deploymentName configured (server dry run)
 `
 
-	want := []Result{
+	want := []applyObjectResult{
 		{"namespace", "namespaceName", "configured"},
 		{"limitrange", "limit-range", "configured"},
 		{"role.rbac.authorization.k8s.io", "auth", "configured"},
@@ -85,7 +85,7 @@ clusterrole.rbac.authorization.k8s.io/system:metrics-server unchanged (server dr
 secret/k8s-auth-conf unchanged (server dry run)
 `
 
-	want := []Result{
+	want := []applyObjectResult{
 		{"namespace", "sys-auth", "configured"},
 		{"rolebinding.rbac.authorization.k8s.io", "vault-configmap-applier", "unchanged"},
 		{"configmap", "vault-tls", "configured"},
@@ -112,7 +112,7 @@ service/serviceName serverside-applied
 deployment.apps/deploymentName serverside-applied
 `
 
-	want := []Result{
+	want := []applyObjectResult{
 		{"namespace", "namespaceName", "serverside-applied"},
 		{"limitrange", "limit-range", "serverside-applied"},
 		{"role.rbac.authorization.k8s.io", "auth", "serverside-applied"},

--- a/run/runner.go
+++ b/run/runner.go
@@ -82,7 +82,6 @@ type Runner struct {
 	DryRun         bool
 	KubeClient     *client.Client
 	KubectlClient  *kubectl.Client
-	Metrics        *metrics.Prometheus
 	PruneBlacklist []string
 	RepoPath       string
 	WorkerCount    int
@@ -157,7 +156,7 @@ func (r *Runner) applyWorker() {
 			// TODO: queue a retry here, with backoff, or better, have scheduler do it
 		}
 
-		r.Metrics.UpdateFromLastRun(request.Application)
+		metrics.UpdateFromLastRun(request.Application)
 
 		log.Logger.Info("Finished apply run", "app", fmt.Sprintf("%s/%s", request.Application.Namespace, request.Application.Name))
 	}

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -108,10 +108,8 @@ var _ = Describe("Runner", func() {
 			KubeClient: testKubeClient,
 			KubectlClient: &kubectl.Client{
 				Host:    testConfig.Host,
-				Metrics: testMetricsClient,
 				Timeout: time.Duration(time.Minute),
 			},
-			Metrics:        testMetricsClient,
 			PruneBlacklist: []string{"apps/v1/ControllerRevision"},
 			RepoPath:       "../testdata/manifests",
 		}

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -106,7 +106,7 @@ func (s *Scheduler) updateApplications() {
 		log.Logger.Error("Could not list Applications: %v", err)
 		return
 	}
-	metrics.ReconcileLastRunTimestamps(apps)
+	metrics.ReconcileFromApplicationList(apps)
 	metrics.UpdateResultSummary(apps)
 	s.applicationsMutex.Lock()
 	for i := range apps {

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/utilitywarehouse/kube-applier/client"
 	"github.com/utilitywarehouse/kube-applier/git"
 	"github.com/utilitywarehouse/kube-applier/log"
+	"github.com/utilitywarehouse/kube-applier/metrics"
 )
 
 // Type defines what kind of apply run is performed.
@@ -55,6 +56,7 @@ type Scheduler struct {
 	ApplicationPollInterval time.Duration
 	GitPollInterval         time.Duration
 	KubeClient              *client.Client
+	Metrics                 *metrics.Prometheus
 	RepoPath                string
 	RunQueue                chan<- Request
 	applications            map[string]*kubeapplierv1alpha1.Application
@@ -111,6 +113,7 @@ func (s *Scheduler) updateApplicationsLoop() {
 				log.Logger.Error("Could not list Applications: %v", err)
 				break
 			}
+			s.Metrics.UpdateResultSummary(apps)
 			s.applicationsMutex.Lock()
 			for i := range apps {
 				app := &apps[i]

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -112,6 +112,7 @@ func (s *Scheduler) updateApplicationsLoop() {
 				log.Logger.Error("Could not list Applications: %v", err)
 				break
 			}
+			metrics.ReconcileLastRunTimestamps(apps)
 			metrics.UpdateResultSummary(apps)
 			s.applicationsMutex.Lock()
 			for i := range apps {

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -100,49 +100,54 @@ func (s *Scheduler) Stop() {
 	s.applicationsMutex.Unlock()
 }
 
+func (s *Scheduler) updateApplications() {
+	apps, err := s.KubeClient.ListApplications(context.TODO())
+	if err != nil {
+		log.Logger.Error("Could not list Applications: %v", err)
+		return
+	}
+	metrics.ReconcileLastRunTimestamps(apps)
+	metrics.UpdateResultSummary(apps)
+	s.applicationsMutex.Lock()
+	for i := range apps {
+		app := &apps[i]
+		if v, ok := s.applications[app.Namespace]; ok {
+			if !reflect.DeepEqual(v.Spec, app.Spec) {
+				s.applicationSchedulers[app.Namespace]()
+				s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
+				s.applications[app.Namespace] = app
+			}
+		} else {
+			s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
+			s.applications[app.Namespace] = app
+		}
+	}
+	for ns := range s.applications {
+		found := false
+		for _, app := range apps {
+			if ns == app.Namespace {
+				found = true
+				break
+			}
+		}
+		if !found {
+			s.applicationSchedulers[ns]()
+			delete(s.applicationSchedulers, ns)
+			delete(s.applications, ns)
+		}
+	}
+	s.applicationsMutex.Unlock()
+}
+
 func (s *Scheduler) updateApplicationsLoop() {
 	ticker := time.NewTicker(s.ApplicationPollInterval)
 	defer ticker.Stop()
 	defer s.waitGroup.Done()
+	s.updateApplications()
 	for {
 		select {
 		case <-ticker.C:
-			apps, err := s.KubeClient.ListApplications(context.TODO())
-			if err != nil {
-				log.Logger.Error("Could not list Applications: %v", err)
-				break
-			}
-			metrics.ReconcileLastRunTimestamps(apps)
-			metrics.UpdateResultSummary(apps)
-			s.applicationsMutex.Lock()
-			for i := range apps {
-				app := &apps[i]
-				if v, ok := s.applications[app.Namespace]; ok {
-					if !reflect.DeepEqual(v.Spec, app.Spec) {
-						s.applicationSchedulers[app.Namespace]()
-						s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
-						s.applications[app.Namespace] = app
-					}
-				} else {
-					s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
-					s.applications[app.Namespace] = app
-				}
-			}
-			for ns := range s.applications {
-				found := false
-				for _, app := range apps {
-					if ns == app.Namespace {
-						found = true
-						break
-					}
-				}
-				if !found {
-					s.applicationSchedulers[ns]()
-					delete(s.applicationSchedulers, ns)
-					delete(s.applications, ns)
-				}
-			}
-			s.applicationsMutex.Unlock()
+			s.updateApplications()
 		case <-s.stop:
 			return
 		}

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -56,7 +56,6 @@ type Scheduler struct {
 	ApplicationPollInterval time.Duration
 	GitPollInterval         time.Duration
 	KubeClient              *client.Client
-	Metrics                 *metrics.Prometheus
 	RepoPath                string
 	RunQueue                chan<- Request
 	applications            map[string]*kubeapplierv1alpha1.Application
@@ -113,7 +112,7 @@ func (s *Scheduler) updateApplicationsLoop() {
 				log.Logger.Error("Could not list Applications: %v", err)
 				break
 			}
-			s.Metrics.UpdateResultSummary(apps)
+			metrics.UpdateResultSummary(apps)
 			s.applicationsMutex.Lock()
 			for i := range apps {
 				app := &apps[i]

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -46,7 +46,6 @@ var _ = Describe("Scheduler", func() {
 			ApplicationPollInterval: time.Second * 5,
 			GitPollInterval:         time.Second * 5,
 			KubeClient:              testKubeClient,
-			Metrics:                 testMetricsClient,
 			RepoPath:                "../testdata/manifests",
 			RunQueue:                testRunQueue,
 		}

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Scheduler", func() {
 			ApplicationPollInterval: time.Second * 5,
 			GitPollInterval:         time.Second * 5,
 			KubeClient:              testKubeClient,
+			Metrics:                 testMetricsClient,
 			RepoPath:                "../testdata/manifests",
 			RunQueue:                testRunQueue,
 		}

--- a/run/suite_test.go
+++ b/run/suite_test.go
@@ -17,7 +17,6 @@ import (
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	"github.com/utilitywarehouse/kube-applier/client"
 	"github.com/utilitywarehouse/kube-applier/log"
-	"github.com/utilitywarehouse/kube-applier/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -27,7 +26,6 @@ import (
 var testConfig *rest.Config
 var testKubeClient *client.Client
 var testEnv *envtest.Environment
-var testMetricsClient = &metrics.Prometheus{}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -70,8 +68,6 @@ var _ = AfterSuite(func() {
 
 func init() {
 	log.InitLogger("off")
-
-	testMetricsClient.Init()
 }
 
 type zeroClock struct{}

--- a/webserver/suite_test.go
+++ b/webserver/suite_test.go
@@ -17,7 +17,6 @@ import (
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	"github.com/utilitywarehouse/kube-applier/client"
 	"github.com/utilitywarehouse/kube-applier/log"
-	"github.com/utilitywarehouse/kube-applier/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -27,7 +26,6 @@ import (
 var testConfig *rest.Config
 var testKubeClient *client.Client
 var testEnv *envtest.Environment
-var testMetricsClient = &metrics.Prometheus{}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -70,8 +68,6 @@ var _ = AfterSuite(func() {
 
 func init() {
 	log.InitLogger("debug")
-
-	testMetricsClient.Init()
 }
 
 type zeroClock struct{}


### PR DESCRIPTION
tl;dr

- prefix all metrics with `kube_applier_`
- re-design the metrics package to better fit the new CRD-based model
- add two new metrics for monitoring the run queue
- add two new metrics that capture Application spec values
- expand integration tests to verify metrics are being exported correctly
