### PR TITLE
Handle multiple Applications in a namespace

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -90,8 +90,8 @@ func newClient(cfg *rest.Config) (*Client, error) {
 }
 
 // EmitApplicationEvent creates an Event for the provided Application.
-func (c *Client) EmitApplicationEvent(app *kubeapplierv1alpha1.Application, eventtype, reason, messageFmt string, args ...interface{}) {
-	c.recorder.Eventf(app, eventtype, reason, messageFmt, args...)
+func (c *Client) EmitApplicationEvent(app *kubeapplierv1alpha1.Application, eventType, reason, messageFmt string, args ...interface{}) {
+	c.recorder.Eventf(app, eventType, reason, messageFmt, args...)
 }
 
 // ListApplications returns a list of all the Application resources.

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,12 +12,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
+	kubeapplierlog "github.com/utilitywarehouse/kube-applier/log"
 	// +kubebuilder:scaffold:imports
+)
+
+const (
+	clientName = "kube-applier"
 )
 
 var (
@@ -41,6 +49,7 @@ func init() {
 type Client struct {
 	client.Client
 	clientset kubernetes.Interface
+	recorder  record.EventRecorder
 }
 
 // New returns a new kubernetes client.
@@ -69,10 +78,20 @@ func newClient(cfg *rest.Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(func(format string, args ...interface{}) { kubeapplierlog.Logger.Debug(fmt.Sprintf(format, args...)) })
+	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: clientName})
 	return &Client{
 		Client:    c,
 		clientset: clientset,
+		recorder:  recorder,
 	}, nil
+}
+
+// EmitApplicationEvent creates an Event for the provided Application.
+func (c *Client) EmitApplicationEvent(app *kubeapplierv1alpha1.Application, eventtype, reason, messageFmt string, args ...interface{}) {
+	c.recorder.Eventf(app, eventtype, reason, messageFmt, args...)
 }
 
 // ListApplications returns a list of all the Application resources.
@@ -81,7 +100,30 @@ func (c *Client) ListApplications(ctx context.Context) ([]kubeapplierv1alpha1.Ap
 	if err := c.List(ctx, apps); err != nil {
 		return nil, err
 	}
-	return apps.Items, nil
+	// ensure that the list of Applications is sorted alphabetically
+	sortedApps := make([]kubeapplierv1alpha1.Application, len(apps.Items))
+	for i, app := range apps.Items {
+		sortedApps[i] = app
+	}
+	sort.Slice(sortedApps, func(i, j int) bool {
+		return sortedApps[i].Namespace+sortedApps[i].Name < sortedApps[j].Namespace+sortedApps[j].Name
+	})
+
+	unique := map[string]kubeapplierv1alpha1.Application{}
+	for _, app := range sortedApps {
+		if v, ok := unique[app.Namespace]; ok {
+			c.EmitApplicationEvent(&app, corev1.EventTypeWarning, "MultipleApplicationsFound", "Application %s is already being used", v.Name)
+			continue
+		}
+		unique[app.Namespace] = app
+	}
+	ret := make([]kubeapplierv1alpha1.Application, len(unique))
+	i := 0
+	for _, app := range unique {
+		ret[i] = app
+		i++
+	}
+	return ret, nil
 }
 
 // GetApplication returns the Application resource specified by the namespace

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Client", func() {
 	})
 })
 
-func matchEvent(app kubeapplierv1alpha1.Application, eventtype, reason, message string) gomegatypes.GomegaMatcher {
+func matchEvent(app kubeapplierv1alpha1.Application, eventType, reason, message string) gomegatypes.GomegaMatcher {
 	return MatchFields(IgnoreExtras, Fields{
 		"TypeMeta": Ignore(),
 		"ObjectMeta": MatchFields(IgnoreExtras, Fields{
@@ -299,6 +299,6 @@ func matchEvent(app kubeapplierv1alpha1.Application, eventtype, reason, message 
 		"Source": MatchFields(IgnoreExtras, Fields{
 			"Component": Equal(clientName),
 		}),
-		"Type": Equal(eventtype),
+		"Type": Equal(eventType),
 	})
 }

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -1,0 +1,69 @@
+package client
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
+	"github.com/utilitywarehouse/kube-applier/log"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var testConfig *rest.Config
+var testKubeClient *Client
+var testEnv *envtest.Environment
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Run package suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "manifests", "base", "crd")},
+	}
+
+	var err error
+	testConfig, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(testConfig).ToNot(BeNil())
+
+	err = kubeapplierv1alpha1.AddToScheme(kubescheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	testKubeClient, err = NewWithConfig(testConfig)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(testKubeClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func init() {
+	log.InitLogger("off")
+}

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -111,9 +111,7 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for i := range apps {
 			if apps[i].Namespace == ns {
 				app = &apps[i]
-				// TODO: handle multiple applications in one namespace. The
-				// behaviour should match that of run.Scheduler, which can also
-				// queue requests.
+				break
 			}
 		}
 		if app == nil {


### PR DESCRIPTION
A namespace can have multiple Application resources defined but
kube-applier can only operate on a single one. To ensure that all
components behave in the same way, client.ListApplication handles
this by considering only the first Application alphabetically and
ignoring any extra objects, while at the same time it emits events to
inform the users.
