### PR TITLE
Fix a rare test failure using Eventually

### DIFF
--- a/webserver/suite_test.go
+++ b/webserver/suite_test.go
@@ -67,7 +67,7 @@ var _ = AfterSuite(func() {
 })
 
 func init() {
-	log.InitLogger("debug")
+	log.InitLogger("off")
 }
 
 type zeroClock struct{}

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -144,8 +144,20 @@ var _ = Describe("WebServer", func() {
 		})
 
 		It("Should render HTML on the root page", func() {
-			res, err := http.Get(fmt.Sprintf("http://localhost:%d/", testWebServer.ListenPort))
-			Expect(err).To(BeNil())
+			var res *http.Response
+			Eventually(
+				func() error {
+					r, err := http.Get(fmt.Sprintf("http://localhost:%d/", testWebServer.ListenPort))
+					if err != nil {
+						return err
+					}
+					res = r
+					return nil
+				},
+				time.Second*15,
+				time.Second,
+			).Should(BeNil())
+
 			body, err := ioutil.ReadAll(res.Body)
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusOK))


### PR DESCRIPTION
The server might not properly be started by the time the test runs,
which can lead to Get() returning ECONNREFUSED.