### PR TITLE
Redesign the log package to support names

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -82,7 +82,7 @@ func newClient(cfg *rest.Config) (*Client, error) {
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(func(format string, args ...interface{}) {
-		kubeapplierlog.Logger.Debug("eventBroadcaster", "msg", fmt.Sprintf(format, args...))
+		kubeapplierlog.Logger("eventBroadcaster").Debug(fmt.Sprintf(format, args...))
 	})
 	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: clientName})

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -65,5 +65,5 @@ var _ = AfterSuite(func() {
 })
 
 func init() {
-	log.InitLogger("off")
+	log.SetLevel("off")
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -5,13 +5,28 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 )
 
-// Logger - Application wide logger obj
-var Logger hclog.Logger
+const (
+	defaultLogLevel = "warn"
+)
 
-// InitLogger - a logger for application wide use
-func InitLogger(logLevel string) {
-	Logger = hclog.New(&hclog.LoggerOptions{
-		Name:  "kube-applier",
-		Level: hclog.LevelFromString(logLevel),
+var (
+	level   = hclog.LevelFromString(defaultLogLevel)
+	loggers = map[string]hclog.Logger{}
+)
+
+// SetLevel sets the global logging level
+func SetLevel(logLevel string) {
+	level = hclog.LevelFromString(logLevel)
+}
+
+// Logger returns an hclog.Logger with the specified name
+func Logger(name string) hclog.Logger {
+	if l, ok := loggers[name]; ok {
+		return l
+	}
+	loggers[name] = hclog.New(&hclog.LoggerOptions{
+		Name:  name,
+		Level: level,
 	})
+	return loggers[name]
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -17,6 +17,9 @@ var (
 // SetLevel sets the global logging level
 func SetLevel(logLevel string) {
 	level = hclog.LevelFromString(logLevel)
+	for _, l := range loggers {
+		l.SetLevel(level)
+	}
 }
 
 // Logger returns an hclog.Logger with the specified name

--- a/log/logger.go
+++ b/log/logger.go
@@ -2,6 +2,8 @@
 package log
 
 import (
+	"sync"
+
 	hclog "github.com/hashicorp/go-hclog"
 )
 
@@ -12,6 +14,7 @@ const (
 var (
 	level   = hclog.LevelFromString(defaultLogLevel)
 	loggers = map[string]hclog.Logger{}
+	m       = sync.Mutex{}
 )
 
 // SetLevel sets the global logging level
@@ -24,8 +27,10 @@ func SetLevel(logLevel string) {
 
 // Logger returns an hclog.Logger with the specified name
 func Logger(name string) hclog.Logger {
-	if l, ok := loggers[name]; ok {
-		return l
+	m.Lock()
+	defer m.Unlock()
+	if _, ok := loggers[name]; ok {
+		return loggers[name]
 	}
 	loggers[name] = hclog.New(&hclog.LoggerOptions{
 		Name:  name,

--- a/main.go
+++ b/main.go
@@ -137,25 +137,25 @@ func validate() {
 func main() {
 	validate()
 
-	log.InitLogger(logLevel)
+	log.SetLevel(logLevel)
 
 	clock := &sysutil.Clock{}
 
 	rt, _ := strconv.Atoi(repoTimeout)
 	if err := sysutil.WaitForDir(repoPath, waitForRepoInterval, time.Duration(rt)*time.Second); err != nil {
-		log.Logger.Error("problem waiting for repo", "path", repoPath, "error", err)
+		log.Logger("kube-applier").Error("problem waiting for repo", "path", repoPath, "error", err)
 		os.Exit(1)
 	}
 
 	kubeClient, err := client.New()
 	if err != nil {
-		log.Logger.Error("error creating kubernetes API client", "error", err)
+		log.Logger("kube-applier").Error("error creating kubernetes API client", "error", err)
 		os.Exit(1)
 	}
 
 	execTimeoutDuration, err := time.ParseDuration(execTimeout)
 	if err != nil {
-		log.Logger.Error("error parsing command exec timeout duration", "timeout", execTimeout, "error", err)
+		log.Logger("kube-applier").Error("error parsing command exec timeout duration", "timeout", execTimeout, "error", err)
 		os.Exit(1)
 	}
 	kubectlClient := &kubectl.Client{
@@ -210,15 +210,15 @@ func main() {
 		StatusUpdateInterval: time.Duration(sui) * time.Second,
 	}
 	if err := webserver.Start(); err != nil {
-		log.Logger.Error(fmt.Sprintf("Cannot start webserver: %v", err))
+		log.Logger("kube-applier").Error(fmt.Sprintf("Cannot start webserver: %v", err))
 		os.Exit(1)
 	}
 
 	ctx := signals.SetupSignalHandler()
 	<-ctx.Done()
-	log.Logger.Info("Interrupted, shutting down...")
+	log.Logger("kube-applier").Info("Interrupted, shutting down...")
 	if err := webserver.Shutdown(); err != nil {
-		log.Logger.Error(fmt.Sprintf("Cannot shutdown webserver: %v", err))
+		log.Logger("kube-applier").Error(fmt.Sprintf("Cannot shutdown webserver: %v", err))
 	}
 	scheduler.Stop()
 	runner.Stop()

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -284,7 +284,7 @@ func parseKubectlOutput(output string) []applyObjectResult {
 		m := kubectlOutputPattern.FindAllStringSubmatch(line, -1)
 		// Should be only 1 match, and should contain 4 elements (0: whole match, 1: resource-type, 2: name, 3: action
 		if len(m) != 1 || len(m[0]) != 4 {
-			log.Logger.Warn("Could not parse output for metrics, expected format: <resource-type>/<name> <action>", "line", line, "full output", output)
+			log.Logger("metrics").Warn("Could not parse output, expected format: <resource-type>/<name> <action>", "line", line, "full output", output)
 			continue
 		}
 		results = append(results, applyObjectResult{

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.InitLogger("info")
+	log.SetLevel("off")
 	os.Exit(m.Run())
 }
 

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -106,7 +106,7 @@ func (s *Scheduler) Stop() {
 func (s *Scheduler) updateApplications() {
 	apps, err := s.KubeClient.ListApplications(context.TODO())
 	if err != nil {
-		log.Logger.Error("Scheduler could not list Applications", "error", err)
+		log.Logger("scheduler").Error("Could not list Applications", "error", err)
 		return
 	}
 	metrics.ReconcileFromApplicationList(apps)
@@ -119,7 +119,7 @@ func (s *Scheduler) updateApplications() {
 				s.applicationSchedulers[app.Namespace]()
 				s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
 				s.applications[app.Namespace] = app
-				log.Logger.Debug("Application changed, updating schedulers", "app", fmt.Sprintf("%s/%s", apps[i].Namespace, apps[i].Name))
+				log.Logger("scheduler").Debug("Application changed, updating schedulers", "app", fmt.Sprintf("%s/%s", apps[i].Namespace, apps[i].Name))
 			}
 		} else {
 			s.applicationSchedulers[app.Namespace] = s.newApplicationLoop(app)
@@ -167,7 +167,7 @@ func (s *Scheduler) gitPollingLoop() {
 		case <-ticker.C:
 			hash, err := s.gitUtil.HeadHashForPaths(".")
 			if err != nil {
-				log.Logger.Warn("Scheduler git polling could not get HEAD hash", "error", err)
+				log.Logger("scheduler").Warn("Git polling could not get HEAD hash", "error", err)
 				break
 			}
 			if hash == s.gitLastQueuedHash {
@@ -183,7 +183,7 @@ func (s *Scheduler) gitPollingLoop() {
 					appId := fmt.Sprintf("%s/%s", s.applications[i].Namespace, s.applications[i].Name)
 					changed, err := s.gitUtil.HasChangesForPath(path, sinceHash)
 					if err != nil {
-						log.Logger.Warn("Could not check path for changes, skipping polling run", "app", appId, "path", path, "since", sinceHash, "error", err)
+						log.Logger("scheduler").Warn("Could not check path for changes, skipping polling run", "app", appId, "path", path, "since", sinceHash, "error", err)
 						continue
 					}
 					if !changed {

--- a/run/suite_test.go
+++ b/run/suite_test.go
@@ -74,7 +74,7 @@ var _ = AfterSuite(func() {
 })
 
 func init() {
-	log.InitLogger("off")
+	log.SetLevel("off")
 }
 
 type zeroClock struct{}

--- a/sysutil/filesystem.go
+++ b/sysutil/filesystem.go
@@ -27,7 +27,7 @@ func ListDirs(rootPath string) ([]string, error) {
 
 // WaitForDir returns when the specified directory is located in the filesystem, or if there is an error opening the directory once it is found.
 func WaitForDir(path string, interval, timeout time.Duration) error {
-	log.Logger.Info("Waiting for the source directory", "path", path, "timeout", timeout.String())
+	log.Logger("filesystem").Info("Waiting for the source directory", "path", path, "timeout", timeout.String())
 
 	to := time.After(timeout)
 
@@ -52,14 +52,14 @@ func WaitForDir(path string, interval, timeout time.Duration) error {
 						err,
 					)
 				}
-				log.Logger.Debug("Failed to get dir info", "path", path, "error", err)
+				log.Logger("filesystem").Debug("Failed to get dir info", "path", path, "error", err)
 			} else if !f.IsDir() {
 				return fmt.Errorf(
 					"%v is not a directory",
 					path,
 				)
 			} else {
-				log.Logger.Info("Found the source directory", "path", path)
+				log.Logger("filesystem").Info("Found the source directory", "path", path)
 				return nil
 			}
 		}

--- a/webserver/suite_test.go
+++ b/webserver/suite_test.go
@@ -67,7 +67,7 @@ var _ = AfterSuite(func() {
 })
 
 func init() {
-	log.InitLogger("off")
+	log.SetLevel("off")
 }
 
 type zeroClock struct{}


### PR DESCRIPTION
This allows log messages to have more context. Each component can use its own named hclog.Logger.