### PR TITLE
Fix tests

### DIFF
--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -131,6 +131,10 @@ var _ = Describe("Runner", func() {
 		metrics.Reset()
 	})
 
+	AfterEach(func() {
+		testRunner.Stop()
+	})
+
 	Context("When operating on an empty Application list", func() {
 		It("Should be a no-op", func() {
 			appList := []kubeapplierv1alpha1.Application{}

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -91,6 +91,10 @@ func (s *Scheduler) Start() {
 
 // Stop gracefully shuts down the Scheduler.
 func (s *Scheduler) Stop() {
+	if s.waitGroup == nil {
+		log.Logger("scheduler").Debug("already stopped or being stopped")
+		return
+	}
 	close(s.stop)
 	s.waitGroup.Wait()
 	s.waitGroup = nil

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -174,6 +174,14 @@ func (s *Scheduler) gitPollingLoop() {
 				log.Logger("scheduler").Warn("Git polling could not get HEAD hash", "error", err)
 				break
 			}
+			// This check prevents the Scheduler from queueing multiple runs for
+			// an Application; without this check, when a new commit appears it
+			// will be eligible for new a run until it finishes the run and its
+			// status is updated.
+			// Applications that are not in the Scheduler's cache when a new
+			// commit appears will not be retroactively checked against the
+			// latest commit when they are acknowledged. This is acceptable,
+			// since they will (eventually) trigger a scheduled run.
 			if hash == s.gitLastQueuedHash {
 				break
 			}

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -226,6 +226,12 @@ var _ = Describe("Scheduler", func() {
 			testEnsureApplications(appList)
 			testWaitForSchedulerToUpdate(&testScheduler, appList)
 
+			// This is a hack to force the scheduler to re-check all
+			// Applications for this test. Otherwise, the test is sensitive to
+			// timing and can fail if the git polling check runs before the
+			// Scheduler has synced all Applications from the apiserver.
+			testScheduler.gitLastQueuedHash = ""
+
 			testWaitForRequests(testSchedulerRequests, MatchAllKeys(Keys{
 				"scheduler-polling-app-a-kustomize": MatchAllKeys(Keys{
 					PollingRun: Equal(1),

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Scheduler", func() {
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Application"},
-					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "app-a"},
+					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "scheduler-polling-app-a"},
 					Spec: kubeapplierv1alpha1.ApplicationSpec{
 						RepositoryPath: "app-a",
 					},
@@ -203,7 +203,7 @@ var _ = Describe("Scheduler", func() {
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Application"},
-					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "app-a-kustomize"},
+					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "scheduler-polling-app-a-kustomize"},
 					Spec: kubeapplierv1alpha1.ApplicationSpec{
 						RepositoryPath: "app-a-kustomize",
 					},
@@ -236,7 +236,7 @@ var _ = Describe("Scheduler", func() {
 				requestCount[req.Application.Namespace][req.Type]++
 			}
 			Expect(requestCount).To(MatchAllKeys(Keys{
-				"app-a-kustomize": MatchAllKeys(Keys{
+				"scheduler-polling-app-a-kustomize": MatchAllKeys(Keys{
 					PollingRun: Equal(1),
 				}),
 			}))

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Scheduler", func() {
 			testEnsureApplications(appList)
 			testWaitForSchedulerToUpdate(&testScheduler, appList)
 
-			t := time.Second * 10
+			t := time.Second * 15
 			if t > 0 {
 				fmt.Printf("Sleeping for ~%v to record queued runs\n", t.Truncate(time.Second))
 				time.Sleep(t)

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Scheduler", func() {
 	})
 
 	AfterEach(func() {
+		testScheduler.Stop()
 		testCleanupNamespaces()
 	})
 


### PR DESCRIPTION
ginkgo (the testing framework) randomises the order in which specs are run so this PR aims to reduce test pollution so that a test cannot affect the outcome of subsequent specs being tested, by:
  - cleaning up CRs after each spec is tested
  - using unique namespaces in specs

Additionally, it address a data race with Scheduler tests which occured when tests would fail (and proactively apply the same fix for Runner tests)

Finally, some changes were made to eliminate cases where tests were time-sensitive and could randomly fail.