### PR TITLE
Add print columns for the Waybill CRD

### DIFF
--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -100,9 +100,9 @@ type WaybillStatusRun struct {
 // +kubebuilder:resource:shortName=wb;wbs
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Success",type=boolean,JSONPath=`.status.lastRun.success`
-// +kubebuilder:printcolumn:name="Last Applied",type=date,JSONPath=`.status.lastRun.finished`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.lastRun.type`
 // +kubebuilder:printcolumn:name="Commit",type=string,JSONPath=`.status.lastRun.commit`
+// +kubebuilder:printcolumn:name="Last Applied",type=date,JSONPath=`.status.lastRun.finished`
 // +kubebuilder:printcolumn:name="Auto Apply",type=boolean,JSONPath=`.spec.autoApply`,priority=10
 // +kubebuilder:printcolumn:name="Dry Run",type=boolean,JSONPath=`.spec.dryRun`,priority=10
 // +kubebuilder:printcolumn:name="Prune",type=boolean,JSONPath=`.spec.prune`,priority=10

--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -99,6 +99,15 @@ type WaybillStatusRun struct {
 // where kubernetes configuration is stored.
 // +kubebuilder:resource:shortName=wb;wbs
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Auto Apply",type=boolean,JSONPath=`.spec.autoApply`
+// +kubebuilder:printcolumn:name="Dry Run",type=boolean,JSONPath=`.spec.dryRun`
+// +kubebuilder:printcolumn:name="Prune",type=boolean,JSONPath=`.spec.prune`,priority=10
+// +kubebuilder:printcolumn:name="Run Interval",type=number,JSONPath=`.spec.runInterval`,priority=10
+// +kubebuilder:printcolumn:name="Repository Path",type=string,JSONPath=`.spec.repositoryPath`,priority=20
+// +kubebuilder:printcolumn:name="Last Run Successful",type=boolean,JSONPath=`.status.lastRun.success`
+// +kubebuilder:printcolumn:name="Last Applied",type=date,JSONPath=`.status.lastRun.finished`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.lastRun.type`,priority=10
+// +kubebuilder:printcolumn:name="Commit",type=string,JSONPath=`.status.lastRun.commit`,priority=10
 type Waybill struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -99,15 +99,15 @@ type WaybillStatusRun struct {
 // where kubernetes configuration is stored.
 // +kubebuilder:resource:shortName=wb;wbs
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Auto Apply",type=boolean,JSONPath=`.spec.autoApply`
-// +kubebuilder:printcolumn:name="Dry Run",type=boolean,JSONPath=`.spec.dryRun`
+// +kubebuilder:printcolumn:name="Success",type=boolean,JSONPath=`.status.lastRun.success`
+// +kubebuilder:printcolumn:name="Last Applied",type=date,JSONPath=`.status.lastRun.finished`
+// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.lastRun.type`
+// +kubebuilder:printcolumn:name="Commit",type=string,JSONPath=`.status.lastRun.commit`
+// +kubebuilder:printcolumn:name="Auto Apply",type=boolean,JSONPath=`.spec.autoApply`,priority=10
+// +kubebuilder:printcolumn:name="Dry Run",type=boolean,JSONPath=`.spec.dryRun`,priority=10
 // +kubebuilder:printcolumn:name="Prune",type=boolean,JSONPath=`.spec.prune`,priority=10
 // +kubebuilder:printcolumn:name="Run Interval",type=number,JSONPath=`.spec.runInterval`,priority=10
 // +kubebuilder:printcolumn:name="Repository Path",type=string,JSONPath=`.spec.repositoryPath`,priority=20
-// +kubebuilder:printcolumn:name="Last Run Successful",type=boolean,JSONPath=`.status.lastRun.success`
-// +kubebuilder:printcolumn:name="Last Applied",type=date,JSONPath=`.status.lastRun.finished`
-// +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.lastRun.type`,priority=10
-// +kubebuilder:printcolumn:name="Commit",type=string,JSONPath=`.status.lastRun.commit`,priority=10
 type Waybill struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/manifests/base/crd/kube-applier.io_waybills.yaml
+++ b/manifests/base/crd/kube-applier.io_waybills.yaml
@@ -19,7 +19,40 @@ spec:
     singular: waybill
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.autoApply
+      name: Auto Apply
+      type: boolean
+    - jsonPath: .spec.dryRun
+      name: Dry Run
+      type: boolean
+    - jsonPath: .spec.prune
+      name: Prune
+      priority: 10
+      type: boolean
+    - jsonPath: .spec.runInterval
+      name: Run Interval
+      priority: 10
+      type: number
+    - jsonPath: .spec.repositoryPath
+      name: Repository Path
+      priority: 20
+      type: string
+    - jsonPath: .status.lastRun.success
+      name: Last Run Successful
+      type: boolean
+    - jsonPath: .status.lastRun.finished
+      name: Last Applied
+      type: date
+    - jsonPath: .status.lastRun.type
+      name: Reason
+      priority: 10
+      type: string
+    - jsonPath: .status.lastRun.commit
+      name: Commit
+      priority: 10
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Waybill is the Schema for the Waybills API of kube-applier. A

--- a/manifests/base/crd/kube-applier.io_waybills.yaml
+++ b/manifests/base/crd/kube-applier.io_waybills.yaml
@@ -20,11 +20,25 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.lastRun.success
+      name: Success
+      type: boolean
+    - jsonPath: .status.lastRun.finished
+      name: Last Applied
+      type: date
+    - jsonPath: .status.lastRun.type
+      name: Reason
+      type: string
+    - jsonPath: .status.lastRun.commit
+      name: Commit
+      type: string
     - jsonPath: .spec.autoApply
       name: Auto Apply
+      priority: 10
       type: boolean
     - jsonPath: .spec.dryRun
       name: Dry Run
+      priority: 10
       type: boolean
     - jsonPath: .spec.prune
       name: Prune
@@ -37,20 +51,6 @@ spec:
     - jsonPath: .spec.repositoryPath
       name: Repository Path
       priority: 20
-      type: string
-    - jsonPath: .status.lastRun.success
-      name: Last Run Successful
-      type: boolean
-    - jsonPath: .status.lastRun.finished
-      name: Last Applied
-      type: date
-    - jsonPath: .status.lastRun.type
-      name: Reason
-      priority: 10
-      type: string
-    - jsonPath: .status.lastRun.commit
-      name: Commit
-      priority: 10
       type: string
     name: v1alpha1
     schema:

--- a/manifests/base/crd/kube-applier.io_waybills.yaml
+++ b/manifests/base/crd/kube-applier.io_waybills.yaml
@@ -23,15 +23,15 @@ spec:
     - jsonPath: .status.lastRun.success
       name: Success
       type: boolean
-    - jsonPath: .status.lastRun.finished
-      name: Last Applied
-      type: date
     - jsonPath: .status.lastRun.type
       name: Reason
       type: string
     - jsonPath: .status.lastRun.commit
       name: Commit
       type: string
+    - jsonPath: .status.lastRun.finished
+      name: Last Applied
+      type: date
     - jsonPath: .spec.autoApply
       name: Auto Apply
       priority: 10


### PR DESCRIPTION
```
$ kubectl -n kube-system get waybills
NAME   SUCCESS   REASON          COMMIT       LAST APPLIED
main   true      Scheduled run   5af0d48ec3   43m
$ kubectl -n kube-system get waybills -o wide
NAME   SUCCESS   REASON          COMMIT       LAST APPLIED   AUTO APPLY   DRY RUN   PRUNE   RUN INTERVAL   REPOSITORY PATH
main   true      Scheduled run   5af0d48ec3   43m            true         false     true    3600           kube-system
```
