### PR TITLE
Add delegateServiceAccountSecretRef field to the CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ metadata:
   name: main
 spec:
   autoApply: true
+  delegateServiceAccountSecretRef: kube-applier-delegate
   dryRun: false
   prune: true
   pruneClusterResources: false
@@ -119,6 +120,19 @@ spec:
 See the documentation on the Waybill CRD
 [spec](https://godoc.org/github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1#WaybillSpec)
 for more details.
+
+#### Delegate Service Account
+
+To avoid leaking access from kube-applier to client namespaces, the concept of a
+delegate Service Account is introduced. When applying a Waybill, kube-applier
+will use the credentials defined in the Secret referenced by
+`delegateServiceAccountSecretRef`. This is a Service Account in the same
+namespace as the Waybill itself and should typically be given admin access to
+the namespace. See the [client base](./manifests/base/client) for an example of
+how to set this up.
+
+This secret should be version controlled but will have to be manually applied
+at first in order to bootstrap the kube-applier integration in a namespace.
 
 #### Integration with `strongbox`
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ See the documentation on the Waybill CRD
 [spec](https://godoc.org/github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1#WaybillSpec)
 for more details.
 
-#### Delegate Service Account
+#### Delegate ServiceAccount
 
 To avoid leaking access from kube-applier to client namespaces, the concept of a
-delegate Service Account is introduced. When applying a Waybill, kube-applier
+delegate ServiceAccount is introduced. When applying a Waybill, kube-applier
 will use the credentials defined in the Secret referenced by
-`delegateServiceAccountSecretRef`. This is a Service Account in the same
+`delegateServiceAccountSecretRef`. This is a ServiceAccount in the same
 namespace as the Waybill itself and should typically be given admin access to
 the namespace. See the [client base](./manifests/base/client) for an example of
 how to set this up.

--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -12,6 +12,13 @@ type WaybillSpec struct {
 	// +kubebuilder:default=true
 	AutoApply *bool `json:"autoApply,omitempty"`
 
+	// DelegateServiceAccountSecretRef references a Secret of type
+	// kubernetes.io/service-account-token in the same namespace as the Waybill
+	// that will be passed by kube-applier to kubectl when performing apply
+	// runs.
+	// +required
+	DelegateServiceAccountSecretRef string `json:"delegateServiceAccountSecretRef"`
+
 	// DryRun enables the dry-run flag when applying this Waybill.
 	// +optional
 	// +kubebuilder:default=false
@@ -48,9 +55,9 @@ type WaybillSpec struct {
 	// +kubebuilder:default=false
 	ServerSideApply bool `json:"serverSideApply,omitempty"`
 
-	// StrongboxKeyringSecretRef reference a Secret in the same namespace as the
-	// Waybill that contains a single item, named '.strongbox_keyring' with any
-	// strongbox keys required to decrypt the files before applying.
+	// StrongboxKeyringSecretRef references a Secret in the same namespace as
+	// the Waybill that contains a single item, named '.strongbox_keyring' with
+	// any strongbox keys required to decrypt the files before applying.
 	// +optional
 	StrongboxKeyringSecretRef string `json:"strongboxKeyringSecretRef,omitempty"`
 }

--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -17,7 +17,7 @@ type WaybillSpec struct {
 	// that will be passed by kube-applier to kubectl when performing apply
 	// runs.
 	// +required
-	DelegateServiceAccountSecretRef string `json:"delegateServiceAccountSecretRef"`
+	DelegateServiceAccountSecretRef *string `json:"delegateServiceAccountSecretRef"`
 
 	// DryRun enables the dry-run flag when applying this Waybill.
 	// +optional
@@ -42,7 +42,8 @@ type WaybillSpec struct {
 
 	// RepositoryPath defines the relative path inside the Repository where the
 	// configuration for this Waybill is stored.
-	RepositoryPath string `json:"repositoryPath"`
+	// +required
+	RepositoryPath *string `json:"repositoryPath"`
 
 	// RunInterval determines how often this Waybill is applied in seconds.
 	// +optional

--- a/apis/kubeapplier/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/kubeapplier/v1alpha1/zz_generated.deepcopy.go
@@ -75,6 +75,11 @@ func (in *WaybillSpec) DeepCopyInto(out *WaybillSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DelegateServiceAccountSecretRef != nil {
+		in, out := &in.DelegateServiceAccountSecretRef, &out.DelegateServiceAccountSecretRef
+		*out = new(string)
+		**out = **in
+	}
 	if in.Prune != nil {
 		in, out := &in.Prune, &out.Prune
 		*out = new(bool)
@@ -84,6 +89,11 @@ func (in *WaybillSpec) DeepCopyInto(out *WaybillSpec) {
 		in, out := &in.PruneBlacklist, &out.PruneBlacklist
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.RepositoryPath != nil {
+		in, out := &in.RepositoryPath, &out.RepositoryPath
+		*out = new(string)
+		**out = **in
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 )
@@ -230,14 +231,17 @@ var _ = Describe("Client", func() {
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "alpha", Namespace: "ns-0"},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{RepositoryPath: pointer.StringPtr("foo"), DelegateServiceAccountSecretRef: pointer.StringPtr("foo")},
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "beta", Namespace: "ns-0"},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{RepositoryPath: pointer.StringPtr("foo"), DelegateServiceAccountSecretRef: pointer.StringPtr("foo")},
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns-1"},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{RepositoryPath: pointer.StringPtr("foo"), DelegateServiceAccountSecretRef: pointer.StringPtr("foo")},
 				},
 			}
 

--- a/manifests/base/client/kustomization.yaml
+++ b/manifests/base/client/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- service-account.yaml

--- a/manifests/base/client/service-account.yaml
+++ b/manifests/base/client/service-account.yaml
@@ -1,0 +1,29 @@
+# Used by kube-applier to apply resources in this namespace
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-applier-delegate
+---
+# Creates a secret with fixed name, populated with the kube-applier-delegate SA
+# data by the token controller.
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: kube-applier-delegate-token
+  annotations:
+    kubernetes.io/service-account.name: kube-applier-delegate
+---
+# The kube-applier-delegate SA should be an admin in this namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-applier-delegate
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kube-applier-delegate

--- a/manifests/base/crd/kube-applier.io_waybills.yaml
+++ b/manifests/base/crd/kube-applier.io_waybills.yaml
@@ -79,6 +79,12 @@ spec:
                 description: AutoApply determines whether this Waybill will be automatically
                   applied by scheduled or polling runs.
                 type: boolean
+              delegateServiceAccountSecretRef:
+                description: DelegateServiceAccountSecretRef references a Secret of
+                  type kubernetes.io/service-account-token in the same namespace as
+                  the Waybill that will be passed by kube-applier to kubectl when
+                  performing apply runs.
+                type: string
               dryRun:
                 default: false
                 description: DryRun enables the dry-run flag when applying this Waybill.
@@ -114,11 +120,13 @@ spec:
                   flag is enabled for this Waybill.
                 type: boolean
               strongboxKeyringSecretRef:
-                description: StrongboxKeyringSecretRef reference a Secret in the same
-                  namespace as the Waybill that contains a single item, named '.strongbox_keyring'
-                  with any strongbox keys required to decrypt the files before applying.
+                description: StrongboxKeyringSecretRef references a Secret in the
+                  same namespace as the Waybill that contains a single item, named
+                  '.strongbox_keyring' with any strongbox keys required to decrypt
+                  the files before applying.
                 type: string
             required:
+            - delegateServiceAccountSecretRef
             - repositoryPath
             type: object
           status:

--- a/run/runner.go
+++ b/run/runner.go
@@ -136,7 +136,7 @@ func (r *Runner) applyWorker() {
 			r.setRequestFailure(request, err)
 			continue
 		}
-		hash, err := gitUtil.HeadHashForPaths(request.Waybill.Spec.RepositoryPath)
+		hash, err := gitUtil.HeadHashForPaths(*request.Waybill.Spec.RepositoryPath)
 		if err != nil {
 			log.Logger("runner").Error("Could not determine HEAD hash", "waybill", wbId, "error", err)
 			r.setRequestFailure(request, err)
@@ -219,7 +219,7 @@ func (r *Runner) copyRepository(waybill *kubeapplierv1alpha1.Waybill) (*git.Util
 			os.RemoveAll(v)
 		}
 	}
-	path := filepath.Join(sub, waybill.Spec.RepositoryPath)
+	path := filepath.Join(sub, *waybill.Spec.RepositoryPath)
 	if err := git.CloneRepository(root, tmpDir, path, env); err != nil {
 		cleanup()
 		return nil, nil, err
@@ -250,7 +250,7 @@ func (r *Runner) setupStrongboxKeyring(waybill *kubeapplierv1alpha1.Waybill) (st
 // Apply takes a list of files and attempts an apply command on each.
 func (r *Runner) apply(rootPath string, waybill *kubeapplierv1alpha1.Waybill, options *ApplyOptions) {
 	start := r.Clock.Now()
-	path := filepath.Join(rootPath, waybill.Spec.RepositoryPath)
+	path := filepath.Join(rootPath, *waybill.Spec.RepositoryPath)
 	log.Logger("runner").Info("Applying files", "path", path)
 
 	dryRunStrategy := "none"

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -49,7 +49,8 @@ func TestApplyOptions_pruneWhitelist(t *testing.T) {
 			&ApplyOptions{},
 			&kubeapplierv1alpha1.Waybill{
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					Prune: pointer.BoolPtr(true),
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(true),
 				},
 			},
 			[]string{},
@@ -59,7 +60,8 @@ func TestApplyOptions_pruneWhitelist(t *testing.T) {
 			applyOptions,
 			&kubeapplierv1alpha1.Waybill{
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					Prune: pointer.BoolPtr(true),
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(true),
 				},
 			},
 			[]string{},
@@ -69,8 +71,9 @@ func TestApplyOptions_pruneWhitelist(t *testing.T) {
 			applyOptions,
 			&kubeapplierv1alpha1.Waybill{
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					Prune:          pointer.BoolPtr(true),
-					PruneBlacklist: []string{"b"},
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(true),
+					PruneBlacklist:                  []string{"b"},
 				},
 			},
 			[]string{"c"},
@@ -80,9 +83,10 @@ func TestApplyOptions_pruneWhitelist(t *testing.T) {
 			applyOptions,
 			&kubeapplierv1alpha1.Waybill{
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					Prune:                 pointer.BoolPtr(true),
-					PruneBlacklist:        []string{"b"},
-					PruneClusterResources: true,
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(true),
+					PruneBlacklist:                  []string{"b"},
+					PruneClusterResources:           true,
 				},
 			},
 			[]string{"c"},
@@ -160,9 +164,10 @@ var _ = Describe("Runner", func() {
 						Namespace: "app-a",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:      pointer.BoolPtr(true),
-						Prune:          pointer.BoolPtr(true),
-						RepositoryPath: "app-a",
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						RepositoryPath:                  pointer.StringPtr("app-a"),
 					},
 				},
 				{
@@ -172,10 +177,11 @@ var _ = Describe("Runner", func() {
 						Namespace: "app-b",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:             pointer.BoolPtr(true),
-						Prune:                 pointer.BoolPtr(true),
-						PruneClusterResources: true,
-						RepositoryPath:        "app-b",
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						PruneClusterResources:           true,
+						RepositoryPath:                  pointer.StringPtr("app-b"),
 					},
 				},
 				{
@@ -185,11 +191,12 @@ var _ = Describe("Runner", func() {
 						Namespace: "app-c",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:      pointer.BoolPtr(true),
-						DryRun:         true,
-						Prune:          pointer.BoolPtr(true),
-						PruneBlacklist: []string{"core/v1/Pod"},
-						RepositoryPath: "app-c",
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						DryRun:                          true,
+						Prune:                           pointer.BoolPtr(true),
+						PruneBlacklist:                  []string{"core/v1/Pod"},
+						RepositoryPath:                  pointer.StringPtr("app-c"),
 					},
 				},
 			}
@@ -235,7 +242,7 @@ Error from server (NotFound): error when creating "../testdata/manifests/app-c/d
 			for i := range wbList {
 				expected[i] = wbList[i]
 				expected[i].Status = kubeapplierv1alpha1.WaybillStatus{LastRun: expectedStatus[i]}
-				headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(expected[i].Spec.RepositoryPath)
+				headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(*expected[i].Spec.RepositoryPath)
 				Expect(err).To(BeNil())
 				expected[i].Status.LastRun.Commit = headCommitHash
 			}
@@ -279,13 +286,14 @@ Error from server (NotFound): error when creating "../testdata/manifests/app-c/d
 					Namespace: "app-a-kustomize",
 				},
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					AutoApply:      pointer.BoolPtr(true),
-					Prune:          pointer.BoolPtr(true),
-					RepositoryPath: "app-a-kustomize",
+					AutoApply:                       pointer.BoolPtr(true),
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(true),
+					RepositoryPath:                  pointer.StringPtr("app-a-kustomize"),
 				},
 			}
 
-			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(waybill.Spec.RepositoryPath)
+			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(*waybill.Spec.RepositoryPath)
 			Expect(err).To(BeNil())
 			expected := waybill
 			expected.Status = kubeapplierv1alpha1.WaybillStatus{
@@ -333,9 +341,10 @@ Some error output has been omitted because it may contain sensitive data
 					Namespace: "app-d",
 				},
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					AutoApply:      pointer.BoolPtr(true),
-					Prune:          pointer.BoolPtr(false),
-					RepositoryPath: "app-d/00-namespace.yaml",
+					AutoApply:                       pointer.BoolPtr(true),
+					DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+					Prune:                           pointer.BoolPtr(false),
+					RepositoryPath:                  pointer.StringPtr("app-d/00-namespace.yaml"),
 				},
 			})
 			ns := &corev1.Namespace{}
@@ -378,9 +387,10 @@ Some error output has been omitted because it may contain sensitive data
 						Namespace: ns.Name,
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:      pointer.BoolPtr(true),
-						Prune:          pointer.BoolPtr(true),
-						RepositoryPath: "app-d",
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						RepositoryPath:                  pointer.StringPtr("app-d"),
 					},
 				},
 				{
@@ -390,10 +400,11 @@ Some error output has been omitted because it may contain sensitive data
 						Namespace: ns.Name,
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:                 pointer.BoolPtr(true),
-						Prune:                     pointer.BoolPtr(true),
-						RepositoryPath:            "app-d",
-						StrongboxKeyringSecretRef: "invalid",
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						RepositoryPath:                  pointer.StringPtr("app-d"),
+						StrongboxKeyringSecretRef:       "invalid",
 					},
 				},
 				{
@@ -403,10 +414,11 @@ Some error output has been omitted because it may contain sensitive data
 						Namespace: ns.Name,
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:                 pointer.BoolPtr(true),
-						Prune:                     pointer.BoolPtr(true),
-						RepositoryPath:            "app-d",
-						StrongboxKeyringSecretRef: secretEmpty.Name,
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						RepositoryPath:                  pointer.StringPtr("app-d"),
+						StrongboxKeyringSecretRef:       secretEmpty.Name,
 					},
 				},
 				{
@@ -416,10 +428,11 @@ Some error output has been omitted because it may contain sensitive data
 						Namespace: ns.Name,
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:                 pointer.BoolPtr(true),
-						Prune:                     pointer.BoolPtr(true),
-						RepositoryPath:            "app-d",
-						StrongboxKeyringSecretRef: secret.Name,
+						AutoApply:                       pointer.BoolPtr(true),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("kube-applier"),
+						Prune:                           pointer.BoolPtr(true),
+						RepositoryPath:                  pointer.StringPtr("app-d"),
+						StrongboxKeyringSecretRef:       secret.Name,
 					},
 				},
 			}
@@ -553,7 +566,7 @@ var _ = Describe("Run Queue", func() {
 				Spec: kubeapplierv1alpha1.WaybillSpec{
 					AutoApply:      pointer.BoolPtr(false),
 					Prune:          pointer.BoolPtr(true),
-					RepositoryPath: "app-a",
+					RepositoryPath: pointer.StringPtr("app-a"),
 				},
 			}
 
@@ -592,7 +605,7 @@ func matchWaybill(expected kubeapplierv1alpha1.Waybill, kubectlPath, kustomizePa
 				"^%s --server %s apply -f [^ ]+/%s -R -n %s%s",
 				kubectlPath,
 				testConfig.Host,
-				expected.Spec.RepositoryPath,
+				*expected.Spec.RepositoryPath,
 				expected.Namespace,
 				commandExtraArgs,
 			)
@@ -600,7 +613,7 @@ func matchWaybill(expected kubeapplierv1alpha1.Waybill, kubectlPath, kustomizePa
 			commandMatcher = MatchRegexp(
 				"^%s build [^ ]+/%s | %s --server %s apply -f - -R -n %s%s",
 				kustomizePath,
-				expected.Spec.RepositoryPath,
+				*expected.Spec.RepositoryPath,
 				kubectlPath,
 				testConfig.Host,
 				expected.Namespace,

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -547,17 +547,6 @@ deployment.apps/test-deployment created
 					TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "app-e",
-						Namespace: "app-e-noca",
-					},
-					Spec: kubeapplierv1alpha1.WaybillSpec{
-						DelegateServiceAccountSecretRef: pointer.StringPtr("ka-noca"),
-						RepositoryPath:                  pointer.StringPtr("app-e"),
-					},
-				},
-				{
-					TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "app-e",
 						Namespace: "app-e",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
@@ -585,15 +574,6 @@ deployment.apps/test-deployment created
 				Type: corev1.SecretTypeServiceAccountToken,
 				Data: map[string][]byte{},
 			})).To(BeNil())
-			Expect(testKubeClient.Update(context.TODO(), &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   "app-e-noca",
-					Name:        "ka-noca",
-					Annotations: map[string]string{corev1.ServiceAccountNameKey: "ka-noca"},
-				},
-				Type: corev1.SecretTypeServiceAccountToken,
-				Data: map[string][]byte{"token": []byte{}},
-			})).To(BeNil())
 
 			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths("app-e")
 			Expect(err).To(BeNil())
@@ -603,7 +583,7 @@ deployment.apps/test-deployment created
 				{
 					Command:      "^.*$",
 					Commit:       "",
-					ErrorMessage: `failed setting up kubeconfig: secrets "ka-notfound" not found`,
+					ErrorMessage: `failed fetching delegate token: secrets "ka-notfound" not found`,
 					Finished:     metav1.Time{},
 					Output:       "",
 					Started:      metav1.Time{},
@@ -613,7 +593,7 @@ deployment.apps/test-deployment created
 				{
 					Command:      "^.*$",
 					Commit:       "",
-					ErrorMessage: `failed setting up kubeconfig: Secret app-e-wrongtype/ka-wrongtype is not of type ` + string(corev1.SecretTypeServiceAccountToken),
+					ErrorMessage: `failed fetching delegate token: Secret app-e-wrongtype/ka-wrongtype is not of type ` + string(corev1.SecretTypeServiceAccountToken),
 					Finished:     metav1.Time{},
 					Output:       "",
 					Started:      metav1.Time{},
@@ -623,17 +603,7 @@ deployment.apps/test-deployment created
 				{
 					Command:      "^.*$",
 					Commit:       "",
-					ErrorMessage: `failed setting up kubeconfig: Secret app-e-notoken/ka-notoken does not contain key 'token'`,
-					Finished:     metav1.Time{},
-					Output:       "",
-					Started:      metav1.Time{},
-					Success:      false,
-					Type:         PollingRun.String(),
-				},
-				{
-					Command:      "^.*$",
-					Commit:       "",
-					ErrorMessage: `failed setting up kubeconfig: Secret app-e-noca/ka-noca does not contain key 'ca.crt'`,
+					ErrorMessage: `failed fetching delegate token: Secret app-e-notoken/ka-notoken does not contain key 'token'`,
 					Finished:     metav1.Time{},
 					Output:       "",
 					Started:      metav1.Time{},
@@ -687,8 +657,6 @@ deployment.apps/test-deployment created
 				`kube_applier_run_latency_seconds`,
 				`kube_applier_run_queue{namespace="app-e-notfound",type="Git polling run"} 0`,
 				`kube_applier_run_queue{namespace="app-e-wrongtype",type="Git polling run"} 0`,
-				`kube_applier_run_queue{namespace="app-e-notoken",type="Git polling run"} 0`,
-				`kube_applier_run_queue{namespace="app-e-noca",type="Git polling run"} 0`,
 				`kube_applier_run_queue{namespace="app-e",type="Git polling run"} 0`,
 			})
 		})

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -192,7 +192,7 @@ func (s *Scheduler) gitPollingLoop() {
 				// and instead rely on the Scheduled run to kickstart things.
 				if s.waybills[i].Status.LastRun != nil && s.waybills[i].Status.LastRun.Commit != hash {
 					sinceHash := s.waybills[i].Status.LastRun.Commit
-					path := s.waybills[i].Spec.RepositoryPath
+					path := *s.waybills[i].Spec.RepositoryPath
 					wbId := fmt.Sprintf("%s/%s", s.waybills[i].Namespace, s.waybills[i].Name)
 					changed, err := s.gitUtil.HasChangesForPath(path, sinceHash)
 					if err != nil {

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	"github.com/utilitywarehouse/kube-applier/git"
+	"github.com/utilitywarehouse/kube-applier/log"
 	"github.com/utilitywarehouse/kube-applier/metrics"
 )
 
@@ -128,7 +129,7 @@ var _ = Describe("Scheduler", func() {
 
 			t := time.Second*15 - time.Since(lastSyncedAt)
 			if t > 0 {
-				fmt.Printf("Sleeping for ~%v to record queued runs\n", t.Truncate(time.Second))
+				log.Logger("test").Info("Sleeping for ~%v to record queued runs\n", t.Truncate(time.Second))
 				time.Sleep(t)
 			}
 			lastSyncedAt = time.Now()
@@ -150,7 +151,7 @@ var _ = Describe("Scheduler", func() {
 
 			t = time.Second*15 - time.Since(lastSyncedAt)
 			if t > 0 {
-				fmt.Printf("Sleeping for ~%v to record queued runs\n", t.Truncate(time.Second))
+				log.Logger("test").Info("Sleeping for ~%v to record queued runs\n", t.Truncate(time.Second))
 				time.Sleep(t)
 			}
 

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -87,8 +87,9 @@ var _ = Describe("Scheduler", func() {
 						Namespace: "foo",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "foo",
-						RunInterval:    5,
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("foo"),
+						RunInterval:                     5,
 					},
 				},
 				{ // no runs should be triggered for this resource, with autoApply false
@@ -98,9 +99,10 @@ var _ = Describe("Scheduler", func() {
 						Namespace: "foo-disabled-auto-apply",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						AutoApply:      pointer.BoolPtr(false),
-						RepositoryPath: "foo",
-						RunInterval:    5,
+						AutoApply:                       pointer.BoolPtr(false),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("foo"),
+						RunInterval:                     5,
 					},
 				},
 			}
@@ -117,7 +119,8 @@ var _ = Describe("Scheduler", func() {
 					Namespace: "bar",
 				},
 				Spec: kubeapplierv1alpha1.WaybillSpec{
-					RepositoryPath: "bar",
+					DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+					RepositoryPath:                  pointer.StringPtr("bar"),
 				},
 			})
 			testEnsureWaybills(wbList)
@@ -184,7 +187,8 @@ var _ = Describe("Scheduler", func() {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "ignored"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "ignored",
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("ignored"),
 					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
@@ -197,7 +201,8 @@ var _ = Describe("Scheduler", func() {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "up-to-date"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "up-to-date",
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("up-to-date"),
 					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
@@ -211,7 +216,8 @@ var _ = Describe("Scheduler", func() {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "scheduler-polling-app-a"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "app-a",
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("app-a"),
 					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
@@ -225,7 +231,8 @@ var _ = Describe("Scheduler", func() {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "scheduler-polling-app-a-kustomize"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "app-a-kustomize",
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("app-a-kustomize"),
 					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
@@ -239,8 +246,9 @@ var _ = Describe("Scheduler", func() {
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "scheduler-polling-app-a-kustomize-no-auto-apply"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "app-a-kustomize",
-						AutoApply:      pointer.BoolPtr(false),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("app-a-kustomize"),
+						AutoApply:                       pointer.BoolPtr(false),
 					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
@@ -281,6 +289,10 @@ var _ = Describe("Scheduler", func() {
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "metrics-foo"},
+					Spec: kubeapplierv1alpha1.WaybillSpec{
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("foo"),
+					},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
 							Finished: metav1.NewTime(time.Now()),
@@ -298,6 +310,10 @@ Some error output has been omitted because it may contain sensitive data
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "metrics-bar"},
+					Spec: kubeapplierv1alpha1.WaybillSpec{
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("foo"),
+					},
 				},
 			}
 			testEnsureWaybills(wbList)
@@ -321,24 +337,27 @@ Some error output has been omitted because it may contain sensitive data
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "spec-foo"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "foo",
-						RunInterval:    5,
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("foo"),
+						RunInterval:                     5,
 					},
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "spec-bar"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "bar",
-						DryRun:         true,
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("bar"),
+						DryRun:                          true,
 					},
 				},
 				{
 					TypeMeta:   metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "spec-baz"},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
-						RepositoryPath: "baz",
-						AutoApply:      pointer.BoolPtr(false),
+						DelegateServiceAccountSecretRef: pointer.StringPtr("foo"),
+						RepositoryPath:                  pointer.StringPtr("baz"),
+						AutoApply:                       pointer.BoolPtr(false),
 					},
 				},
 			}
@@ -369,9 +388,16 @@ func testEnsureWaybills(wbList []*kubeapplierv1alpha1.Waybill) {
 		if err != nil && !errors.IsAlreadyExists(err) {
 			Expect(err).To(BeNil())
 		}
+		// The ResourceVersion swapping is to prevent the respective error from
+		// Create() which makes it difficult to handle it below.
+		rv := wbList[i].ResourceVersion
+		wbList[i].ResourceVersion = ""
 		err = testKubeClient.Create(context.TODO(), wbList[i])
-		if err != nil {
+		if err != nil && errors.IsAlreadyExists(err) {
+			wbList[i].ResourceVersion = rv
 			Expect(testKubeClient.UpdateWaybill(context.TODO(), wbList[i])).To(BeNil())
+		} else {
+			Expect(err).To(BeNil())
 		}
 		if wbList[i].Status.LastRun != nil {
 			// UpdateStatus changes SelfLink to the status sub-resource but we

--- a/run/suite_test.go
+++ b/run/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -64,6 +65,10 @@ var _ = BeforeSuite(func(done Done) {
 	testKubeClient, err = client.NewWithConfig(testConfig)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(testKubeClient).ToNot(BeNil())
+
+	hostParts := strings.Split(testConfig.Host, ":")
+	os.Setenv("KUBERNETES_SERVICE_HOST", hostParts[0])
+	os.Setenv("KUBERNETES_SERVICE_PORT", hostParts[1])
 
 	close(done)
 }, 60)

--- a/templates/status.html
+++ b/templates/status.html
@@ -85,7 +85,7 @@
                                                 <strong>Commit: </strong> {{ if $.CommitLink $wb.Status.LastRun.Commit }}<a href="{{ $.CommitLink $wb.Status.LastRun.Commit }}">{{ $wb.Status.LastRun.Commit }}</a>{{ end }}<br/>
                                                 <strong>Started: </strong>{{ $.FormattedTime $wb.Status.LastRun.Started }} (took {{ $.Latency $wb.Status.LastRun.Started $wb.Status.LastRun.Finished }})
                                             </div>
-                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force wb</strong></button></div>
+                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
                                         </div>
                                     </li>
                                     <li class="list-group-item">

--- a/testdata/manifests/app-e/00-namespace.yaml
+++ b/testdata/manifests/app-e/00-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: app-e

--- a/testdata/manifests/app-e/deployment.yaml
+++ b/testdata/manifests/app-e/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  labels:
+    app: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+      - name: alpine
+        image: alpine
+        command:
+          - /bin/sh
+          - -c
+          - sleep 3600


### PR DESCRIPTION
Every Waybill needs to define a secret which contains the token for a Service Account that is to be used when applying its namespace.