### PR TITLE
Use a default for delegateServiceAccountSecretRef

### DIFF
--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -17,6 +17,7 @@ type WaybillSpec struct {
 	// that will be passed by kube-applier to kubectl when performing apply
 	// runs.
 	// +required
+	// +kubebuilder:default=kube-applier-delegate-token
 	DelegateServiceAccountSecretRef *string `json:"delegateServiceAccountSecretRef"`
 
 	// DryRun enables the dry-run flag when applying this Waybill.

--- a/manifests/base/crd/kube-applier.io_waybills.yaml
+++ b/manifests/base/crd/kube-applier.io_waybills.yaml
@@ -80,6 +80,7 @@ spec:
                   applied by scheduled or polling runs.
                 type: boolean
               delegateServiceAccountSecretRef:
+                default: kube-applier-delegate-token
                 description: DelegateServiceAccountSecretRef references a Secret of
                   type kubernetes.io/service-account-token in the same namespace as
                   the Waybill that will be passed by kube-applier to kubectl when


### PR DESCRIPTION
This works well with the client namespace base provided.