### PR TITLE
Capture run setup errors in kubernetes events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 * [Usage](#usage)
     * [Environment variables](#environment-variables)
     * [Waybill CRD](#waybill-crd)
+        * [Delegate ServiceAccount](#delegate-serviceaccount)
+        * [Integration with `strongbox`](#integration-with-strongbox)
     * [Mounting the Git Repository](#mounting-the-git-repository)
     * [Resource pruning](#resource-pruning)
 * [Deploying](#deploying)

--- a/client/client.go
+++ b/client/client.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	clientName = "kube-applier"
+	// Name identifies this client and is used for ownership-related fields.
+	Name = "kube-applier"
 )
 
 var (
@@ -44,7 +45,6 @@ func init() {
 		log.Fatalf("Cannot setup client scheme: %v", err)
 	}
 	// +kubebuilder:scaffold:scheme
-
 }
 
 // Client encapsulates a kubernetes client for interacting with the apiserver.
@@ -85,7 +85,7 @@ func newClient(cfg *rest.Config) (*Client, error) {
 		kubeapplierlog.Logger("eventBroadcaster").Debug(fmt.Sprintf(format, args...))
 	})
 	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: clientset.CoreV1().Events("")})
-	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: clientName})
+	recorder := eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: Name})
 	return &Client{
 		Client:    c,
 		clientset: clientset,

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -300,7 +300,7 @@ func matchEvent(waybill kubeapplierv1alpha1.Waybill, eventType, reason, message 
 		"Message": MatchRegexp(message),
 		"Reason":  Equal(reason),
 		"Source": MatchFields(IgnoreExtras, Fields{
-			"Component": Equal(clientName),
+			"Component": Equal(Name),
 		}),
 		"Type": Equal(eventType),
 	})


### PR DESCRIPTION
Errors during the setup steps of a run request are currently logged by
kube-applier but not presented to the user. The implementation of
setRequestFailure() is incomplete and so they are never presented to the
user.

These errors that do not originate from kubectl better fit in the
concept of a kubernetes event. Instead of updating the status
subresource of the Waybill, we can instead emit events. This will
maintain the information of the actual last run in the status of the
Waybill but still surface the issue to the user.