### PR TITLE
Add empty spec to the client base Waybill

### DIFF
--- a/manifests/base/client/waybill.yaml
+++ b/manifests/base/client/waybill.yaml
@@ -2,3 +2,4 @@ apiVersion: kube-applier.io/v1alpha1
 kind: Waybill
 metadata:
   name: main
+spec: {}


### PR DESCRIPTION
Defaults do not apply if the spec is omitted.