### PR TITLE
Set default for Waybill spec

### DIFF
--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -127,6 +127,8 @@ type Waybill struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:default={autoApply:true}
+	// +optional
 	Spec   WaybillSpec   `json:"spec,omitempty"`
 	Status WaybillStatus `json:"status,omitempty"`
 }

--- a/manifests/base/client/waybill.yaml
+++ b/manifests/base/client/waybill.yaml
@@ -2,4 +2,3 @@ apiVersion: kube-applier.io/v1alpha1
 kind: Waybill
 metadata:
   name: main
-spec: {}

--- a/manifests/base/cluster/kube-applier.io_waybills.yaml
+++ b/manifests/base/cluster/kube-applier.io_waybills.yaml
@@ -72,6 +72,8 @@ spec:
           metadata:
             type: object
           spec:
+            default:
+              autoApply: true
             description: WaybillSpec defines the desired state of Waybill
             properties:
               autoApply:


### PR DESCRIPTION
Since all attributes are optional, we should allow omitting the Waybill
spec. Currently this means that default values for the attributes do not
apply, which causes kube-applier to panic.

Making the filed required means we have to define `spec: {}` in the
Waybill definition and it doesn't look very clean. Instead, we can
define a default value for it.

However, the controller-tools generator currently seems to ignore
an emtpy object `{}` as a default value. We could set this manually but
it becomes error prone if we have to manually fix every time we generate
the CRDs. Instead we can simply define a single attribute in this
default object and `autoApply` was chosen because it is a default that
is very unlikely to change.