### PR TITLE
Remove Waybill from client base

### DIFF
--- a/manifests/base/client/kustomization.yaml
+++ b/manifests/base/client/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - service-account.yaml
-  - waybill.yaml

--- a/manifests/base/client/waybill.yaml
+++ b/manifests/base/client/waybill.yaml
@@ -1,4 +1,0 @@
-apiVersion: kube-applier.io/v1alpha1
-kind: Waybill
-metadata:
-  name: main


### PR DESCRIPTION
In many cases the client will have to patch this resource so it does not
make sense to include it in the base for the few cases that default
functionality is required.

Additionally, it is clearer if client namespaces always version control
their Waybill.