### PR TITLE
Implement shared strongbox keyring whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ Alternatively, if you need to use a different name, you will need to create a
 Role and a RoleBinding to give `"get"` permission to it.
 
 If you need to deploy a shared strongbox keyring to use in multiple namespaces,
-the Secret should have an annotation called `"allowed-namespaces"` which
-contains a comma-seperated list of all the namespaces that are allowed to use
-it. For example, the following secret can be used by namespaces "ns-a", "ns-b"
-and "ns-c":
+the Secret should have an annotation called
+`"kube-applier.io/allowed-namespaces"` which contains a comma-seperated list of
+all the namespaces that are allowed to use it. For example, the following secret
+can be used by namespaces "ns-a", "ns-b" and "ns-c":
 
 ```
 kind: Secret
@@ -174,7 +174,7 @@ metadata:
   name: kube-applier-strongbox-keyring
   namespace: ns-a
   annotations:
-    allowed-namespaces: "ns-b,ns-c"
+    kube-applier.io/allowed-namespaces: "ns-b,ns-c"
 stringData:
   .strongbox_keyring: |-
       keyentries:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,24 @@ Role and a RoleBinding to give `"get"` permission to it.
 If you need to deploy a shared strongbox keyring to use in multiple namespaces,
 the Secret should have an annotation called `"allowed-namespaces"` which
 contains a comma-seperated list of all the namespaces that are allowed to use
-it.
+it. For example, the following secret can be used by namespaces "ns-a", "ns-b"
+and "ns-c":
+
+```
+kind: Secret
+apiVersion: v1
+metadata:
+  name: kube-applier-strongbox-keyring
+  namespace: ns-a
+  annotations:
+    allowed-namespaces: "ns-b,ns-c"
+stringData:
+  .strongbox_keyring: |-
+      keyentries:
+      - description: mykey
+        key-id: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
 
 The secret containing the strongbox keyring should itself be version controlled
 to prevent kube-applier from pruning it. However, since it is a secret itself

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Table of Contents
 
+<!-- vim-markdown-toc GFM -->
+
 * [Usage](#usage)
     * [Environment variables](#environment-variables)
     * [Waybill CRD](#waybill-crd)
@@ -18,6 +20,8 @@
 * [Running locally](#running-locally)
 * [Running tests](#running-tests)
 * [Copyright and License](#copyright-and-license)
+
+<!-- vim-markdown-toc -->
 
 Forked from: https://github.com/box/kube-applier
 
@@ -151,42 +155,16 @@ applying the Waybill, allowing for decryption of files under the
 `repositoryPath`. If the attribute `namespace` for `stronboxKeyringSecretRef` is
 not specified then it defaults to the same namespace as the Waybill itself.
 
-This secret will be retrieved when performing an apply run using the delegate
-ServiceAccount token (see the section above). Therefore this ServiceAccount
-should have read access to the Secret. If the Secret is in the same namespace
-with the Waybill, the delegate account should have access to it since it will
-be bound to the `admin` ClusterRole. However, in cases where a shared strongbox
-keyring is setup, you will need to set it up like so (in the namespace where
-the Secret is created):
+This secret should be readable by the ServiceAccount of kube-applier. If
+deployed using the provided kustomize bases, kube-applier's ServiceAccount will
+have read access to secrets named `"kube-applier-stronbox-keyring"` by default.
+Alternatively, if you need to use a different name, you will need to create a
+Role and a RoleBinding to give `"get"` permission to it.
 
-```
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: kube-applier-strongbox-keyring-ro
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: ["strongbox-keyring"]
-    verbs: ["get"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kube-applier-strongbox-keyring-ro
-roleRef:
-  kind: Role
-  name: kube-applier-strongbox-keyring-ro
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: kube-applier-delegate
-    namespace: namespace-a
-  - kind: ServiceAccount
-    name: kube-applier-delegate
-    namespace: namespace-b
-[ ... ]
-```
+If you need to deploy a shared strongbox keyring to use in multiple namespaces,
+the Secret should have an annotation called `"allowed-namespaces"` which
+contains a comma-seperated list of all the namespaces that are allowed to use
+it.
 
 The secret containing the strongbox keyring should itself be version controlled
 to prevent kube-applier from pruning it. However, since it is a secret itself

--- a/client/client.go
+++ b/client/client.go
@@ -95,14 +95,6 @@ func newClient(cfg *rest.Config) (*Client, error) {
 	}, nil
 }
 
-// WithToken returns a copy of the Client that will perform actions using the
-// provided token.
-func (c *Client) WithToken(token string) (*Client, error) {
-	cfg := rest.AnonymousClientConfig(c.cfg)
-	cfg.BearerToken = token
-	return newClient(cfg)
-}
-
 // EmitWaybillEvent creates an Event for the provided Waybill.
 func (c *Client) EmitWaybillEvent(waybill *kubeapplierv1alpha1.Waybill, eventType, reason, messageFmt string, args ...interface{}) {
 	c.recorder.Eventf(waybill, eventType, reason, messageFmt, args...)

--- a/manifests/base/cluster/clusterrole.yaml
+++ b/manifests/base/cluster/clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["kube-applier-delegate-token"]
+    resourceNames: ["kube-applier-delegate-token", "kube-applier-stronbox-keyring"]
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["events"]

--- a/run/runner.go
+++ b/run/runner.go
@@ -30,7 +30,7 @@ const (
 	defaultRunnerWorkerCount = 2
 	defaultWorkerQueueSize   = 512
 
-	strongboxKeyringAllowedNamespacesAnnotation = "allowed-namespaces"
+	strongboxKeyringAllowedNamespacesAnnotation = "kube-applier.io/allowed-namespaces"
 )
 
 // Request defines an apply run request

--- a/run/runner.go
+++ b/run/runner.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 const (
 	defaultRunnerWorkerCount = 2
 	defaultWorkerQueueSize   = 512
+
+	strongboxKeyringAllowedNamespacesAnnotation = "allowed-namespaces"
 )
 
 // Request defines an apply run request
@@ -133,7 +136,7 @@ func (r *Runner) applyWorker() {
 			r.captureRequestFailure(request, fmt.Errorf("failed fetching delegate token: %w", err))
 			continue
 		}
-		tmpRepoPath, cleanupTemp, err := r.setupRepositoryClone(request.Waybill, delegateToken)
+		tmpRepoPath, cleanupTemp, err := r.setupRepositoryClone(request.Waybill)
 		if err != nil {
 			r.captureRequestFailure(request, fmt.Errorf("failed setting up repository clone: %w", err))
 			continue
@@ -205,7 +208,7 @@ func (r *Runner) getDelegateToken(waybill *kubeapplierv1alpha1.Waybill) (string,
 	return string(delegateToken), nil
 }
 
-func (r *Runner) setupRepositoryClone(waybill *kubeapplierv1alpha1.Waybill, delegateToken string) (string, func(), error) {
+func (r *Runner) setupRepositoryClone(waybill *kubeapplierv1alpha1.Waybill) (string, func(), error) {
 	var env []string
 	// strongbox integration
 	if waybill.Spec.StrongboxKeyringSecretRef != nil {
@@ -213,13 +216,22 @@ func (r *Runner) setupRepositoryClone(waybill *kubeapplierv1alpha1.Waybill, dele
 		if sbNamespace == "" {
 			sbNamespace = waybill.Namespace
 		}
-		delegateClient, err := r.KubeClient.WithToken(delegateToken)
+		secret, err := r.KubeClient.GetSecret(context.TODO(), sbNamespace, waybill.Spec.StrongboxKeyringSecretRef.Name)
 		if err != nil {
 			return "", nil, err
 		}
-		secret, err := delegateClient.GetSecret(context.TODO(), sbNamespace, waybill.Spec.StrongboxKeyringSecretRef.Name)
-		if err != nil {
-			return "", nil, err
+		if sbNamespace != waybill.Namespace {
+			sbAllowedNamespaces := strings.Split(secret.Annotations[strongboxKeyringAllowedNamespacesAnnotation], ",")
+			sbAllowed := false
+			for _, v := range sbAllowedNamespaces {
+				if v == waybill.Namespace {
+					sbAllowed = true
+					break
+				}
+			}
+			if !sbAllowed {
+				return "", nil, fmt.Errorf(`secret "%s/%s" cannot be used in namespace "%s", the namespace must be listed in the '%s' annotation`, secret.Namespace, secret.Name, waybill.Namespace, strongboxKeyringAllowedNamespacesAnnotation)
+			}
 		}
 		strongboxData, ok := secret.Data[".strongbox_keyring"]
 		if !ok {

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -386,6 +386,19 @@ Some error output has been omitted because it may contain sensitive data
 					TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "app-d",
+						Namespace: "app-d-strongbox-shared-not-allowed",
+					},
+					Spec: kubeapplierv1alpha1.WaybillSpec{
+						AutoApply:                 pointer.BoolPtr(true),
+						Prune:                     pointer.BoolPtr(true),
+						RepositoryPath:            "app-d",
+						StrongboxKeyringSecretRef: &kubeapplierv1alpha1.ObjectReference{Name: "strongbox", Namespace: "app-d"},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-d",
 						Namespace: "app-d-strongbox-shared",
 					},
 					Spec: kubeapplierv1alpha1.WaybillSpec{
@@ -401,8 +414,9 @@ Some error output has been omitted because it may contain sensitive data
 
 			Expect(testKubeClient.Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "strongbox",
-					Namespace: "app-d",
+					Name:        "strongbox",
+					Namespace:   "app-d",
+					Annotations: map[string]string{strongboxKeyringAllowedNamespacesAnnotation: "app-d-strongbox-shared"},
 				},
 				StringData: map[string]string{
 					".strongbox_keyring": `keyentries:
@@ -451,6 +465,7 @@ deployment.apps/test-deployment created
 					Success: true,
 					Type:    PollingRun.String(),
 				},
+				nil,
 				{
 					Command:      "",
 					Commit:       headCommitHash,


### PR DESCRIPTION
Instead of relying on RBAC to share a strongbox keyring secret, an
annotation is introduced to act as a whitelist. This prevents admins of
a namespace from fetching the Secret directly on the cluster. Also, it
makes shared strongbox keyring setups simpler, since no additional RBAC
is required, just an annotation on the Secret itself.

The strongbox keyring Secret is no longer fetched using the delegate
ServiceAccount token, instead we use kube-applier's ServiceAccount to do
so. Whether a namespace is allowed to use a strongbox keyring Secret
outside its own namespace is determined by looking at this whitelist
annotation. Consequently, kube-applier's ClusterRole has been updated to
allow access to Secrets name "kube-applier-strongbox-keyring" by
default.