### PR TITLE
Waybill status matcher

### DIFF
--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -753,29 +753,29 @@ func matchWaybill(expected kubeapplierv1alpha1.Waybill, kubectlPath, kustomizePa
 					commandExtraArgs,
 				)
 			}
-			lastRunMatcher = PointTo(MatchAllFields(Fields{
-				"Command":      commandMatcher,
-				"Commit":       Equal(expected.Status.LastRun.Commit),
-				"ErrorMessage": Equal(expected.Status.LastRun.ErrorMessage),
-				"Finished": And(
-					Equal(expected.Status.LastRun.Finished),
-					// Ideally we would be comparing to actual's Started but since it
-					// should be equal to expected' Started, this is equivalent.
-					MatchAllFields(Fields{
-						"Time": BeTemporally(">=", expected.Status.LastRun.Started.Time),
-					}),
-				),
-				"Output": MatchRegexp("^%s$", strings.Replace(
-					regexp.QuoteMeta(expected.Status.LastRun.Output),
-					regexp.QuoteMeta(repoPath),
-					"[^ ]+",
-					-1,
-				)),
-				"Started": Equal(expected.Status.LastRun.Started),
-				"Success": Equal(expected.Status.LastRun.Success),
-				"Type":    Equal(expected.Status.LastRun.Type),
-			}))
 		}
+		lastRunMatcher = PointTo(MatchAllFields(Fields{
+			"Command":      commandMatcher,
+			"Commit":       Equal(expected.Status.LastRun.Commit),
+			"ErrorMessage": Equal(expected.Status.LastRun.ErrorMessage),
+			"Finished": And(
+				Equal(expected.Status.LastRun.Finished),
+				// Ideally we would be comparing to actual's Started but since it
+				// should be equal to expected' Started, this is equivalent.
+				MatchAllFields(Fields{
+					"Time": BeTemporally(">=", expected.Status.LastRun.Started.Time),
+				}),
+			),
+			"Output": MatchRegexp("^%s$", strings.Replace(
+				regexp.QuoteMeta(expected.Status.LastRun.Output),
+				regexp.QuoteMeta(repoPath),
+				"[^ ]+",
+				-1,
+			)),
+			"Started": Equal(expected.Status.LastRun.Started),
+			"Success": Equal(expected.Status.LastRun.Success),
+			"Type":    Equal(expected.Status.LastRun.Type),
+		}))
 	}
 	return MatchAllFields(Fields{
 		"TypeMeta":   Equal(expected.TypeMeta),


### PR DESCRIPTION
Allows passing custom regex matcher for the Command and Output fields of the Waybill status.

This enables testing cases where these fields diverge from their normal values, which are typically constructed in the `matchWaybill` method.