### PR TITLE
Introduce RunTimeout to Waybill

### DIFF
--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -64,6 +64,11 @@ type WaybillSpec struct {
 	// +kubebuilder:default=3600
 	RunInterval int `json:"runInterval,omitempty"`
 
+	// RunTimeout specifies the timeout for performing an apply run.
+	// +optional
+	// +kubebuilder:default=900
+	RunTimeout int `json:"runTimeout,omitempty"`
+
 	// ServerSideApply determines whether the server-side apply flag is enabled
 	// for this Waybill.
 	// +optional

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -24,8 +23,6 @@ import (
 )
 
 var (
-	// To make testing possible
-	execCommand = exec.Command
 	// The output is omitted if it contains any of these terms when there is an
 	// error running `kubectl apply -f <path>`
 	omitErrOutputTerms   = []string{"Secret", "base64"}
@@ -87,14 +84,13 @@ func (o *ApplyOptions) SetCommandEnvironment(cmd *exec.Cmd) {
 
 // Client enables communication with the Kubernetes API Server through kubectl commands.
 type Client struct {
-	Host    string
-	Label   string
-	Timeout time.Duration
+	Host  string
+	Label string
 }
 
 // Apply attempts to "kubectl apply" the files located at path. It returns the
 // full apply command and its output.
-func (c *Client) Apply(path string, options ApplyOptions) (string, string, error) {
+func (c *Client) Apply(ctx context.Context, path string, options ApplyOptions) (string, string, error) {
 	var kustomize bool
 	if _, err := os.Stat(path + "/kustomization.yaml"); err == nil {
 		kustomize = true
@@ -104,10 +100,10 @@ func (c *Client) Apply(path string, options ApplyOptions) (string, string, error
 		kustomize = true
 	}
 	if kustomize {
-		cmd, out, err := c.applyKustomize(path, options)
+		cmd, out, err := c.applyKustomize(ctx, path, options)
 		return sanitiseCmdStr(cmd), out, err
 	}
-	cmd, out, err := c.applyPath(path, options)
+	cmd, out, err := c.applyPath(ctx, path, options)
 	return sanitiseCmdStr(cmd), out, err
 }
 
@@ -124,8 +120,8 @@ func (c *Client) KustomizePath() string {
 }
 
 // applyPath runs `kubectl apply -f <path>`
-func (c *Client) applyPath(path string, options ApplyOptions) (string, string, error) {
-	cmdStr, out, err := c.apply(path, []byte{}, options)
+func (c *Client) applyPath(ctx context.Context, path string, options ApplyOptions) (string, string, error) {
+	cmdStr, out, err := c.apply(ctx, path, []byte{}, options)
 	if err != nil {
 		// Filter potential secret leaks out of the output
 		return cmdStr, filterErrOutput(out), err
@@ -135,11 +131,8 @@ func (c *Client) applyPath(path string, options ApplyOptions) (string, string, e
 }
 
 // applyKustomize does a `kustomize build | kubectl apply -f -` on the path
-func (c *Client) applyKustomize(path string, options ApplyOptions) (string, string, error) {
+func (c *Client) applyKustomize(ctx context.Context, path string, options ApplyOptions) (string, string, error) {
 	var kustomizeStdout, kustomizeStderr bytes.Buffer
-
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancel()
 
 	kustomizeCmd := exec.CommandContext(ctx, "kustomize", "build", path)
 	options.SetCommandEnvironment(kustomizeCmd)
@@ -193,7 +186,7 @@ func (c *Client) applyKustomize(path string, options ApplyOptions) (string, stri
 		resourcesOptions := options
 		resourcesOptions.PruneWhitelist = resourcesPruneWhitelist
 
-		_, out, err := c.apply("-", resources, resourcesOptions)
+		_, out, err := c.apply(ctx, "-", resources, resourcesOptions)
 		kubectlOut = kubectlOut + out
 		if err != nil {
 			return cmdStr, kubectlOut, err
@@ -212,7 +205,7 @@ func (c *Client) applyKustomize(path string, options ApplyOptions) (string, stri
 		secretsOptions := options
 		secretsOptions.PruneWhitelist = secretsPruneWhitelist
 
-		_, out, err := c.apply("-", secrets, secretsOptions)
+		_, out, err := c.apply(ctx, "-", secrets, secretsOptions)
 		if err != nil {
 			// Don't append the actual output, as the error output
 			// from kubectl can leak the content of secrets
@@ -226,7 +219,7 @@ func (c *Client) applyKustomize(path string, options ApplyOptions) (string, stri
 }
 
 // apply runs `kubectl apply`
-func (c *Client) apply(path string, stdin []byte, options ApplyOptions) (string, string, error) {
+func (c *Client) apply(ctx context.Context, path string, stdin []byte, options ApplyOptions) (string, string, error) {
 	args := []string{}
 	if c.Host != "" {
 		args = append(args, "--server", c.Host)
@@ -236,9 +229,6 @@ func (c *Client) apply(path string, stdin []byte, options ApplyOptions) (string,
 		args = append(args, "-R")
 	}
 	args = append(args, options.Args()...)
-
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancel()
 
 	kubectlCmd := exec.CommandContext(ctx, "kubectl", args...)
 	options.SetCommandEnvironment(kubectlCmd)

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ var (
 	dryRun               = os.Getenv("DRY_RUN")
 	logLevel             = os.Getenv("LOG_LEVEL")
 	pruneBlacklist       = os.Getenv("PRUNE_BLACKLIST")
-	execTimeout          = os.Getenv("EXEC_TIMEOUT")
 
 	// Github commit diff url
 	diffURLFormat = os.Getenv("DIFF_URL_FORMAT")
@@ -119,10 +118,6 @@ func validate() {
 		logLevel = "warn"
 	}
 
-	if execTimeout == "" {
-		execTimeout = "3m"
-	}
-
 	if workerCount == "" {
 		workerCount = "0"
 	}
@@ -153,14 +148,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	execTimeoutDuration, err := time.ParseDuration(execTimeout)
-	if err != nil {
-		log.Logger("kube-applier").Error("error parsing command exec timeout duration", "timeout", execTimeout, "error", err)
-		os.Exit(1)
-	}
-	kubectlClient := &kubectl.Client{
-		Timeout: execTimeoutDuration,
-	}
+	kubectlClient := &kubectl.Client{}
 
 	// Kubernetes copies annotations from StatefulSets, Deployments and
 	// Daemonsets to the corresponding ControllerRevision, including

--- a/manifests/base/cluster/kube-applier.io_waybills.yaml
+++ b/manifests/base/cluster/kube-applier.io_waybills.yaml
@@ -139,6 +139,11 @@ spec:
                 description: RunInterval determines how often this Waybill is applied
                   in seconds.
                 type: integer
+              runTimeout:
+                default: 900
+                description: RunTimeout specifies the timeout for performing an apply
+                  run.
+                type: integer
               serverSideApply:
                 default: false
                 description: ServerSideApply determines whether the server-side apply

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -106,13 +106,10 @@ var _ = Describe("Runner", func() {
 
 	BeforeEach(func() {
 		testRunner = Runner{
-			Clock:      &zeroClock{},
-			DryRun:     false,
-			KubeClient: testKubeClient,
-			KubectlClient: &kubectl.Client{
-				Host:    testConfig.Host,
-				Timeout: time.Duration(time.Minute),
-			},
+			Clock:          &zeroClock{},
+			DryRun:         false,
+			KubeClient:     testKubeClient,
+			KubectlClient:  &kubectl.Client{Host: testConfig.Host},
 			PruneBlacklist: []string{"apps/v1/ControllerRevision"},
 			RepoPath:       "../testdata/manifests",
 			WorkerCount:    1, // limit to one to prevent race issues

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -238,7 +238,7 @@ deployment.apps/test-deployment created (server dry run)
 				if repositoryPath == "" {
 					repositoryPath = expected[i].Namespace
 				}
-				headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(repositoryPath)
+				headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(context.TODO(), repositoryPath)
 				Expect(err).To(BeNil())
 				expected[i].Status.LastRun.Commit = headCommitHash
 			}
@@ -293,7 +293,7 @@ deployment.apps/test-deployment created (server dry run)
 			if repositoryPath == "" {
 				repositoryPath = waybill.Namespace
 			}
-			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(repositoryPath)
+			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(context.TODO(), repositoryPath)
 			Expect(err).To(BeNil())
 			expected := waybill
 			expected.Status = kubeapplierv1alpha1.WaybillStatus{
@@ -447,7 +447,7 @@ QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 				Type:       corev1.SecretTypeOpaque,
 			})).To(BeNil())
 
-			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths("app-b-kustomize")
+			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(context.TODO(), "app-b-kustomize")
 			Expect(err).To(BeNil())
 			Expect(headCommitHash).ToNot(BeEmpty())
 
@@ -657,7 +657,7 @@ deployment.apps/test-deployment created
 				Type: corev1.SecretTypeOpaque,
 			})).To(BeNil())
 
-			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths("app-d")
+			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(context.TODO(), "app-d")
 			Expect(err).To(BeNil())
 			Expect(headCommitHash).ToNot(BeEmpty())
 
@@ -812,7 +812,7 @@ deployment.apps/test-deployment created
 				Data: map[string][]byte{},
 			})).To(BeNil())
 
-			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths("app-e")
+			headCommitHash, err := (&git.Util{RepoPath: testRunner.RepoPath}).HeadHashForPaths(context.TODO(), "app-e")
 			Expect(err).To(BeNil())
 			Expect(headCommitHash).ToNot(BeEmpty())
 

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -165,13 +165,13 @@ var _ = Describe("Scheduler", func() {
 
 		It("Should trigger runs for Waybills that have had their source change in git", func() {
 			gitUtil := &git.Util{RepoPath: "../testdata/manifests"}
-			headHash, err := gitUtil.HeadHashForPaths(".")
+			headHash, err := gitUtil.HeadHashForPaths(context.TODO(), ".")
 			Expect(err).To(BeNil())
 			Expect(headHash).ToNot(BeEmpty())
-			appAHeadHash, err := gitUtil.HeadHashForPaths("app-a")
+			appAHeadHash, err := gitUtil.HeadHashForPaths(context.TODO(), "app-a")
 			Expect(err).To(BeNil())
 			Expect(appAHeadHash).ToNot(BeEmpty())
-			appAKHeadHash, err := gitUtil.HeadHashForPaths("app-a-kustomize")
+			appAKHeadHash, err := gitUtil.HeadHashForPaths(context.TODO(), "app-a-kustomize")
 			Expect(err).To(BeNil())
 			Expect(appAKHeadHash).ToNot(BeEmpty())
 


### PR DESCRIPTION
Remove the global `EXEC_TIMEOUT` variable and implement a run timeout per Waybill.

Additionally, update contexts in the Scheduler and Webserver methods to appropriate values.