### PR TITLE
Enable passing multiple SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,15 +195,17 @@ first time (or after any changes to its contents).
 
 #### Custom SSH Keys
 
-You can specify a custom SSH key to be used for fetching remote `kustomize`
-bases from private repositories. In order to do that, you will need to specify
-`gitSSHSecretRef`: it should reference a `Secret` that contains the SSH key in
-the value of the `"key"` item. The SSH key should of course have access to the
-private repository that contains the bases. Additionally this `Secret` can
+You can specify custom SSH keys to be used for fetching remote `kustomize` bases
+from private repositories. In order to do that, you will need to specify
+`gitSSHSecretRef`: it should reference a `Secret` that contains one or more SSH
+keys that provide access to the private repositories that contain these bases.
+
+In this `Secret`, items with a name that begins with `"key_*"` are treated as
+SSH keys to be used with `kustomize`. Additionally this `Secret` can optionally
 define a value for `"known_hosts"`. If ommitted, `git` will use `ssh` with
 `StrictHostKeyChecking` disabled.
 
-To use the ssh key for `kustomize` bases, the bases should be defined with the
+To use an ssh key for `kustomize` bases, the bases should be defined with the
 `ssh://` scheme in `kustomization.yaml`. For example:
 ```
 bases:
@@ -225,7 +227,11 @@ metadata:
   annotations:
     kube-applier.io/allowed-namespaces: "ns-b, ns-c"
 stringData:
-  key: |-
+  key_a: |-
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    -----END OPENSSH PRIVATE KEY-----
+  key_b: |-
     -----BEGIN OPENSSH PRIVATE KEY-----
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
     -----END OPENSSH PRIVATE KEY-----

--- a/run/runner.go
+++ b/run/runner.go
@@ -304,9 +304,8 @@ func (r *Runner) setupGitSSH(ctx context.Context, waybill *kubeapplierv1alpha1.W
 	// Using IdentitiesOnly=yes and passing the key with IdentityFile= ensures
 	// that ssh will not try to fallback to the standard key locations for the
 	// user, accidentally using a key that it should not.
-	gitSSHCommand := `GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes -o IdentityFile=%[1]s/.ssh_key -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`
 	if waybill.Spec.GitSSHSecretRef == nil {
-		return fmt.Sprintf(gitSSHCommand, tmpHomeDir), nil
+		return fmt.Sprintf(`GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes -o IdentityFile=%s/.ssh_key_invalid -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`, tmpHomeDir), nil
 	}
 	gsNamespace := waybill.Spec.GitSSHSecretRef.Namespace
 	if gsNamespace == "" {
@@ -319,26 +318,34 @@ func (r *Runner) setupGitSSH(ctx context.Context, waybill *kubeapplierv1alpha1.W
 	if err := checkSecretIsAllowed(waybill, secret); err != nil {
 		return "", err
 	}
-	gitSSHKey, ok := secret.Data["key"]
-	if !ok {
-		return "", fmt.Errorf(`secret "%s/%s" does not contain key 'key'`, secret.Namespace, secret.Name)
-	}
-	// if the file containing the ssh key does not have a newline at the end,
-	// ssh does not complain about it but the key will not work properly
-	if !bytes.HasSuffix(gitSSHKey, []byte("\n")) {
-		gitSSHKey = append(gitSSHKey, byte('\n'))
-	}
-	if err := os.WriteFile(filepath.Join(tmpHomeDir, ".ssh_key"), gitSSHKey, 0400); err != nil {
-		return "", err
-	}
-	gitSSHKnownHosts, ok := secret.Data["known_hosts"]
-	if ok {
-		if err := os.WriteFile(filepath.Join(tmpHomeDir, ".ssh_known_hosts"), gitSSHKnownHosts, 0400); err != nil {
-			return "", err
+	knownHostsFragment := `-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no`
+	keyFragments := []string{}
+	for k, v := range secret.Data {
+		if strings.HasPrefix(k, "key_") {
+			// if the file containing the ssh key does not have a newline at the end,
+			// ssh does not complain about it but the key will not work properly
+			if !bytes.HasSuffix(v, []byte("\n")) {
+				v = append(v, byte('\n'))
+			}
+			keyFilename := filepath.Join(tmpHomeDir, fmt.Sprintf(".ssh_%s", k))
+			if err := os.WriteFile(keyFilename, v, 0400); err != nil {
+				return "", err
+			}
+			// keys (identity files) are used by ssh sequentially (in the same
+			// order in which they are defined in the command line) until a
+			// valid key is found for a given remote
+			keyFragments = append(keyFragments, fmt.Sprintf(`-o IdentityFile=%s`, keyFilename))
+		} else if k == "known_hosts" {
+			if err := os.WriteFile(filepath.Join(tmpHomeDir, ".ssh_known_hosts"), v, 0400); err != nil {
+				return "", err
+			}
+			knownHostsFragment = fmt.Sprintf(`-o UserKnownHostsFile=%[1]s/.ssh_known_hosts`, tmpHomeDir)
 		}
-		gitSSHCommand = `GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes -o IdentityFile=%[1]s/.ssh_key -o UserKnownHostsFile=%[1]s/.ssh_known_hosts`
 	}
-	return fmt.Sprintf(gitSSHCommand, tmpHomeDir), nil
+	if len(keyFragments) == 0 {
+		return "", fmt.Errorf(`secret "%s/%s" does not contain any keys`, secret.Namespace, secret.Name)
+	}
+	return fmt.Sprintf(`GIT_SSH_COMMAND=ssh -q -F none -o IdentitiesOnly=yes %s %s`, strings.Join(keyFragments, " "), knownHostsFragment), nil
 }
 
 // Apply takes a list of files and attempts an apply command on each.


### PR DESCRIPTION
This in turn allows `kustomize` to pull remote bases from multiple
private repositories, as long as there is at least one key which
provides access to each repository.
