### PR TITLE
Fixes for the git sync process

### DIFF
--- a/git/repository.go
+++ b/git/repository.go
@@ -152,7 +152,7 @@ func (r *Repository) StopSync() {
 
 func (r *Repository) runGitCommand(ctx context.Context, environment []string, cwd string, args ...string) (string, error) {
 	cmdStr := "git " + strings.Join(args, " ")
-	log.Logger("repository").Info("running command", "cwd", cwd, "cmd", cmdStr)
+	log.Logger("repository").Debug("running command", "cwd", cwd, "cmd", cmdStr)
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if cwd != "" {
@@ -176,7 +176,7 @@ func (r *Repository) runGitCommand(ctx context.Context, environment []string, cw
 	if err != nil {
 		return "", fmt.Errorf("Run(%s): %w: { stdout: %q, stderr: %q }", cmdStr, err, stdout, stderr)
 	}
-	log.Logger("repository").Info("command result", "stdout", stdout, "stderr", stderr)
+	log.Logger("repository").Debug("command result", "stdout", stdout, "stderr", stderr)
 
 	return stdout, nil
 }

--- a/git/repository.go
+++ b/git/repository.go
@@ -19,6 +19,14 @@ import (
 	"github.com/utilitywarehouse/kube-applier/metrics"
 )
 
+var (
+	gitExecutablePath string
+)
+
+func init() {
+	gitExecutablePath = exec.Command("git").String()
+}
+
 // RepositoryConfig defines a remote git repository.
 type RepositoryConfig struct {
 	Remote   string
@@ -151,10 +159,10 @@ func (r *Repository) StopSync() {
 }
 
 func (r *Repository) runGitCommand(ctx context.Context, environment []string, cwd string, args ...string) (string, error) {
-	cmdStr := "git " + strings.Join(args, " ")
+	cmdStr := gitExecutablePath + " " + strings.Join(args, " ")
 	log.Logger("repository").Debug("running command", "cwd", cwd, "cmd", cmdStr)
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd := exec.CommandContext(ctx, gitExecutablePath, args...)
 	if cwd != "" {
 		cmd.Dir = cwd
 	}

--- a/git/repository.go
+++ b/git/repository.go
@@ -241,6 +241,7 @@ func (r *Repository) sync(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		return nil
 	case err != nil:
 		return fmt.Errorf("error checking if repo exists %q: %v", gitRepoPath, err)
 	default:
@@ -272,6 +273,10 @@ func (r *Repository) sync(ctx context.Context) error {
 	}
 	// GC clone
 	if _, err := r.runGitCommand(ctx, nil, r.path, "gc", "--prune=all"); err != nil {
+		return err
+	}
+	// Reset HEAD
+	if _, err = r.runGitCommand(ctx, nil, r.path, "reset", "--soft", fmt.Sprintf("origin/%s", r.repositoryConfig.Branch)); err != nil {
 		return err
 	}
 	return nil

--- a/git/repository.go
+++ b/git/repository.go
@@ -305,8 +305,8 @@ func (r *Repository) cloneRemote(ctx context.Context) error {
 	return nil
 }
 
-// CloneRepository creates a clone of the existing repository to a new location
-// on disk and only checkouts the specified subpath. On success, it returns the
+// CloneLocal creates a clone of the existing repository to a new location on
+// disk and only checkouts the specified subpath. On success, it returns the
 // hash of the new repository clone's HEAD.
 func (r *Repository) CloneLocal(ctx context.Context, environment []string, dst, subpath string) (string, error) {
 	r.lock.Lock()

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -75,7 +75,7 @@ func (o *ApplyOptions) Args() []string {
 	return args
 }
 
-func (o *ApplyOptions) SetCommandEnvironment(cmd *exec.Cmd) {
+func (o *ApplyOptions) setCommandEnvironment(cmd *exec.Cmd) {
 	if len(o.Environment) > 0 {
 		cmd.Env = append(os.Environ(), o.Environment...)
 	}
@@ -134,7 +134,7 @@ func (c *Client) applyKustomize(ctx context.Context, path string, options ApplyO
 	var kustomizeStdout, kustomizeStderr bytes.Buffer
 
 	kustomizeCmd := exec.CommandContext(ctx, "kustomize", "build", path)
-	options.SetCommandEnvironment(kustomizeCmd)
+	options.setCommandEnvironment(kustomizeCmd)
 	kustomizeCmd.Stdout = &kustomizeStdout
 	kustomizeCmd.Stderr = &kustomizeStderr
 
@@ -230,7 +230,7 @@ func (c *Client) apply(ctx context.Context, path string, stdin []byte, options A
 	args = append(args, options.Args()...)
 
 	kubectlCmd := exec.CommandContext(ctx, "kubectl", args...)
-	options.SetCommandEnvironment(kubectlCmd)
+	options.setCommandEnvironment(kubectlCmd)
 	if path == "-" {
 		if len(stdin) == 0 {
 			return "", "", fmt.Errorf("path can't be %s when stdin is empty", path)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	repoPath              = os.Getenv("REPO_PATH")
 	repoTimeout           = os.Getenv("REPO_TIMEOUT_SECONDS")
 	listenPort            = os.Getenv("LISTEN_PORT")
-	gitPollInterval       = os.Getenv("GIT_POLL_INTERVAL_SECONDS")
+	gitPollWait           = os.Getenv("GIT_POLL_WAIT_SECONDS")
 	waybillPollInterval   = os.Getenv("WAYBILL_POLL_INTERVAL_SECONDS")
 	statusUpdateInterval  = os.Getenv("STATUS_UPDATE_INTERVAL_SECONDS")
 	dryRun                = os.Getenv("DRY_RUN")
@@ -100,12 +100,12 @@ func validate() {
 		os.Exit(1)
 	}
 
-	if gitPollInterval == "" {
-		gitPollInterval = "5"
+	if gitPollWait == "" {
+		gitPollWait = "10"
 	} else {
-		_, err := strconv.Atoi(gitPollInterval)
+		_, err := strconv.Atoi(gitPollWait)
 		if err != nil {
-			fmt.Println("GIT_POLL_INTERVAL_SECONDS must be an int")
+			fmt.Println("GIT_POLL_WAIT_SECONDS must be an int")
 			os.Exit(1)
 		}
 	}
@@ -221,11 +221,11 @@ func main() {
 
 	runQueue := runner.Start()
 
-	gpi, _ := strconv.Atoi(gitPollInterval)
+	gpw, _ := strconv.Atoi(gitPollWait)
 	wpi, _ := strconv.Atoi(waybillPollInterval)
 	scheduler := &run.Scheduler{
 		Clock:               clock,
-		GitPollInterval:     time.Duration(gpi) * time.Second,
+		GitPollWait:         time.Duration(gpw) * time.Second,
 		KubeClient:          kubeClient,
 		Repository:          repo,
 		RepoPath:            repoPath,

--- a/main.go
+++ b/main.go
@@ -19,13 +19,6 @@ import (
 	"github.com/utilitywarehouse/kube-applier/webserver"
 )
 
-const (
-	// Number of seconds to wait in between attempts to locate the repo at the
-	// specified path. Git-sync atomically places the repo at the specified path
-	// once it is finished pulling, so it will not be present immediately.
-	waitForRepoInterval = 1 * time.Second
-)
-
 var (
 	repoRemote            = os.Getenv("REPO_REMOTE")
 	repoBranch            = os.Getenv("REPO_BRANCH")

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -318,6 +318,7 @@ func UpdateRunRequest(t string, waybill *kubeapplierv1alpha1.Waybill, diff float
 
 // Reset deletes all metrics. This is exported for use in integration tests.
 func Reset() {
+	gitSyncCount.Reset()
 	kubectlExitCodeCount.Reset()
 	namespaceApplyCount.Reset()
 	runLatency.Reset()

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -340,7 +340,7 @@ func parseKubectlOutput(output string) []applyObjectResult {
 		m := kubectlOutputPattern.FindAllStringSubmatch(line, -1)
 		// Should be only 1 match, and should contain 4 elements (0: whole match, 1: resource-type, 2: name, 3: action
 		if len(m) != 1 || len(m[0]) != 4 {
-			log.Logger("metrics").Warn("Could not parse output, expected format: <resource-type>/<name> <action>", "line", line, "full output", output)
+			log.Logger("metrics").Debug("Could not parse output, expected format: <resource-type>/<name> <action>", "line", line, "full output", output)
 			continue
 		}
 		results = append(results, applyObjectResult{

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -249,6 +249,8 @@ func ReconcileFromWaybillList(waybills []kubeapplierv1alpha1.Waybill) {
 	}
 }
 
+// RecordGitSync records a git repository sync attempt by updating all the
+// relevant metrics
 func RecordGitSync(success bool) {
 	if success {
 		gitLastSyncTimestamp.Set(float64(time.Now().Unix()))

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -197,8 +197,8 @@ func (s *Scheduler) processGitChanges() {
 	// commit when they are acknowledged. This is acceptable, since they
 	// will (eventually) trigger a scheduled run.
 	s.waybillsMutex.Lock()
+	defer s.waybillsMutex.Unlock()
 	if hash == s.gitLastQueuedHash {
-		s.waybillsMutex.Unlock()
 		return
 	}
 	log.Logger("scheduler").Debug("New HEAD hash detected, checking for Waybills that need to be applied", "hash", hash)
@@ -224,7 +224,6 @@ func (s *Scheduler) processGitChanges() {
 		}
 	}
 	s.gitLastQueuedHash = hash
-	s.waybillsMutex.Unlock()
 }
 
 func (s *Scheduler) newWaybillLoop(waybill *kubeapplierv1alpha1.Waybill) func() {

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -201,6 +201,7 @@ func (s *Scheduler) processGitChanges() {
 		s.waybillsMutex.Unlock()
 		return
 	}
+	log.Logger("scheduler").Debug("New HEAD hash detected, checking for Waybills that need to be applied", "hash", hash)
 	for i := range s.waybills {
 		// If LastRun is nil, we don't trigger the Polling run at all
 		// and instead rely on the Scheduled run to kickstart things.

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Scheduler", func() {
 		testScheduler = Scheduler{
 			WaybillPollInterval: time.Second * 5,
 			Clock:               &zeroClock{},
-			GitPollInterval:     time.Second * 5,
+			GitPollWait:         time.Second * 5,
 			KubeClient:          testKubeClient,
 			Repository:          testRepository,
 			RepoPath:            "testdata/manifests",


### PR DESCRIPTION
- The git `sync()` method now resets the local branch HEAD to the remote branch HEAD. This was left out previously and apart from not working correctly in updating the local clone it also caused spiky memory behaviour and excessive CPU consumption
- Tiny optimisation that only looks up `git` once and then uses the absolute path in command invocations
- Change `GitPollInterval` to `GitPollWait` and the process to *wait* in-between invocations. This avoids a timeout that occurred due to the previously short timeout and the use of a mutex in `Repository`
- Small changes based on golint suggestions
- Adjusted log levels to reduce output