### PR TITLE
OIDC-based authorization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.4 // indirect
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/securecookie v1.1.1
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/kr/pretty v0.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/utilitywarehouse/go-operational v0.0.0-20190722153447-b0f3f6284543
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
 	golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d // indirect
-	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93 // indirect
+	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
 	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ var (
 	fOidcCallbackURL      = flag.String("oidc-callback-url", getStringEnv("OIDC_CALLBACK_URL", ""), "OIDC callback url should be the root URL where kube-applier is exposed")
 	fOidcClientID         = flag.String("oidc-client-id", getStringEnv("OIDC_CLIENT_ID", ""), "Client ID of the OIDC application")
 	fOidcClientSecret     = flag.String("oidc-client-secret", getStringEnv("OIDC_CLIENT_SECRET", ""), "Client secret of the OIDC application")
-	fOidcDomain           = flag.String("oidc-domain", getStringEnv("OIDC_DOMAIN", ""), "OIDC domain is the domain of the authentication server")
+	fOidcIssuer           = flag.String("oidc-issuer", getStringEnv("OIDC_ISSUER", ""), "OIDC issuer URL of the authentication server")
 	fPruneBlacklist       = flag.String("prune-blacklist", getStringEnv("PRUNE_BLACKLIST", ""), "Comma-seperated list of resources to add to the global prune blacklist, in the <group>/<version>/<kind> format")
 	fRepoBranch           = flag.String("repo-branch", getStringEnv("REPO_BRANCH", "master"), "Branch of the git repository to use")
 	fRepoDepth            = flag.Int("repo-depth", getIntEnv("REPO_DEPTH", 0), "Depth of the git repository to fetch. Use zero to ignore")
@@ -102,9 +102,9 @@ func main() {
 		err               error
 	)
 
-	if strings.Join([]string{*fOidcDomain, *fOidcClientID, *fOidcClientSecret, *fOidcCallbackURL}, "") != "" {
+	if strings.Join([]string{*fOidcIssuer, *fOidcClientID, *fOidcClientSecret, *fOidcCallbackURL}, "") != "" {
 		oidcAuthenticator, err = oidc.NewAuthenticator(
-			*fOidcDomain,
+			*fOidcIssuer,
 			*fOidcClientID,
 			*fOidcClientSecret,
 			*fOidcCallbackURL,
@@ -113,7 +113,7 @@ func main() {
 			log.Logger("kube-applier").Error("could not setup oidc authenticator", "error", err)
 			os.Exit(1)
 		}
-		log.Logger("kube-applier").Info("OIDC authentication configured", "domain", *fOidcDomain, "clientID", *fOidcClientID)
+		log.Logger("kube-applier").Info("OIDC authentication configured", "issuer", *fOidcIssuer, "clientID", *fOidcClientID)
 	}
 
 	repo, err := git.NewRepository(

--- a/manifests/base/cluster/clusterrole.yaml
+++ b/manifests/base/cluster/clusterrole.yaml
@@ -19,3 +19,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -19,12 +19,12 @@ function forceRun(namespace) {
         url: url,
         data: {namespace: namespace},
         dataType: "json",
-        success:function(data) {
-            showForceAlert(true, data.message)
+        success: function(data) {
+            showForceAlert(true, data.message);
             $('.force-button').each(function(){ $(this).prop('disabled', false); });
         },
-        error:function() {
-            showForceAlert(false, 'Server error attempting to force a run. See container logs for more info.')
+        error: function(xhr) {
+            showForceAlert(false, 'Error: ' +  xhr.responseJSON.message + '<br/>See container logs for more info.');
             $('.force-button').each(function(){ $(this).prop('disabled', false); });
         }
     });

--- a/webserver/oidc/oidc.go
+++ b/webserver/oidc/oidc.go
@@ -31,9 +31,7 @@ const (
 
 var (
 	codeVerifierCharsetLen = big.NewInt(int64(len(codeVerifierCharset)))
-	codeVerifierLenMin     = big.NewInt(43)
-	codeVerifierLenMax     = big.NewInt(128)
-	codeVerifierLenRange   = big.NewInt(0).Sub(codeVerifierLenMax, codeVerifierLenMin)
+	codeVerifierLen        = 128
 	secureCookie           *securecookie.SecureCookie
 
 	// ErrRedirectRequired is returned by Authenticator.Authenticate if a
@@ -156,13 +154,8 @@ func (u *userSession) Save(w http.ResponseWriter) error {
 }
 
 func (u *userSession) newCodeVerifier() error {
-	cvl, err := rand.Int(rand.Reader, codeVerifierLenRange)
-	if err != nil {
-		return err
-	}
-	cvLen := int(cvl.Add(cvl, codeVerifierLenMin).Int64())
-	cv := make([]byte, cvLen)
-	for i := 0; i < cvLen; i++ {
+	cv := make([]byte, codeVerifierLen)
+	for i := 0; i < codeVerifierLen; i++ {
 		num, err := rand.Int(rand.Reader, codeVerifierCharsetLen)
 		if err != nil {
 			return err

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -114,7 +114,7 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				data.Result = "error"
 				data.Message = "not authenticated"
-				log.Logger("webserver").Error("User not authenticated", "error", err)
+				log.Logger("webserver").Error(data.Message, "error", err)
 				w.WriteHeader(http.StatusForbidden)
 				break
 			}
@@ -122,8 +122,8 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if err := r.ParseForm(); err != nil {
 			data.Result = "error"
-			data.Message = "Could not parse form data"
-			log.Logger("webserver").Error("Could not process force run request", "error", data.Message)
+			data.Message = "could not parse form data"
+			log.Logger("webserver").Error(data.Message, "error", err)
 			w.WriteHeader(http.StatusBadRequest)
 			break
 		}
@@ -131,8 +131,8 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ns := r.FormValue("namespace")
 		if ns == "" {
 			data.Result = "error"
-			data.Message = "Empty namespace value"
-			log.Logger("webserver").Error("Could not process force run request", "error", data.Message)
+			data.Message = "empty namespace value"
+			log.Logger("webserver").Error(data.Message)
 			w.WriteHeader(http.StatusBadRequest)
 			break
 		}
@@ -140,7 +140,8 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		waybills, err := f.KubeClient.ListWaybills(r.Context())
 		if err != nil {
 			data.Result = "error"
-			data.Message = "Cannot list Waybills"
+			data.Message = "cannot list Waybills"
+			log.Logger("webserver").Error(data.Message, "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			break
 		}
@@ -154,7 +155,7 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if waybill == nil {
 			data.Result = "error"
-			data.Message = fmt.Sprintf("Cannot find Waybills in namespace '%s'", ns)
+			data.Message = fmt.Sprintf("cannot find Waybills in namespace '%s'", ns)
 			w.WriteHeader(http.StatusBadRequest)
 			break
 		}
@@ -164,7 +165,7 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			hasAccess, err := f.KubeClient.HasAccess(r.Context(), waybill, userEmail, "patch")
 			if !hasAccess {
 				data.Result = "error"
-				data.Message = fmt.Sprintf("User %s is not allowed to force a run on waybill %s/%s", userEmail, waybill.Namespace, waybill.Name)
+				data.Message = fmt.Sprintf("user %s is not allowed to force a run on waybill %s/%s", userEmail, waybill.Namespace, waybill.Name)
 				if err != nil {
 					log.Logger("webserver").Error(data.Message, "error", err)
 				}
@@ -179,9 +180,8 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	default:
 		data.Result = "error"
-		data.Message = "Must be a POST request"
+		data.Message = "must be a POST request"
 		w.WriteHeader(http.StatusBadRequest)
-		log.Logger("webserver").Error("Could not process force run request", "error", data.Message)
 	}
 
 	w.Header().Set("Content-Type", "waybill/json; charset=UTF-8")

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/utilitywarehouse/kube-applier/log"
 	"github.com/utilitywarehouse/kube-applier/run"
 	"github.com/utilitywarehouse/kube-applier/sysutil"
+	"github.com/utilitywarehouse/kube-applier/webserver/oidc"
 )
 
 const (
@@ -29,6 +30,7 @@ const (
 
 // WebServer struct
 type WebServer struct {
+	Authenticator        *oidc.Authenticator
 	Clock                sysutil.ClockInterface
 	DiffURLFormat        string
 	KubeClient           *client.Client
@@ -44,14 +46,27 @@ type WebServer struct {
 // StatusPageHandler implements the http.Handler interface and serves a status
 // page with info about the most recent applier run.
 type StatusPageHandler struct {
-	Clock    sysutil.ClockInterface
-	Result   *Result
-	Template *template.Template
+	Authenticator *oidc.Authenticator
+	Clock         sysutil.ClockInterface
+	Result        *Result
+	Template      *template.Template
 }
 
 // ServeHTTP populates the status page template with data and serves it when
 // there is a request.
 func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.Authenticator != nil {
+		_, err := s.Authenticator.Authenticate(r.Context(), w, r)
+		if errors.Is(err, oidc.ErrRedirectRequired) {
+			return
+		}
+		if err != nil {
+			http.Error(w, "Error: Authentication failed", http.StatusInternalServerError)
+			log.Logger("webserver").Error("Authentication failed", "error", err, "time", s.Clock.Now().String())
+			return
+		}
+	}
+
 	log.Logger("webserver").Info("Applier status request", "time", s.Clock.Now().String())
 	if s.Template == nil {
 		http.Error(w, "Error: Unable to load HTML template", http.StatusInternalServerError)
@@ -74,8 +89,9 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // ForceRunHandler implements the http.Handle interface and serves an API
 // endpoint for forcing a new run.
 type ForceRunHandler struct {
-	KubeClient *client.Client
-	RunQueue   chan<- run.Request
+	Authenticator *oidc.Authenticator
+	KubeClient    *client.Client
+	RunQueue      chan<- run.Request
 }
 
 // ServeHTTP handles requests for forcing a run by attempting to add to the
@@ -89,6 +105,21 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
+		var (
+			userEmail string
+			err       error
+		)
+		if f.Authenticator != nil {
+			userEmail, err = f.Authenticator.UserEmail(r.Context(), r)
+			if err != nil {
+				data.Result = "error"
+				data.Message = "not authenticated"
+				log.Logger("webserver").Error("User not authenticated", "error", err)
+				w.WriteHeader(http.StatusForbidden)
+				break
+			}
+		}
+
 		if err := r.ParseForm(); err != nil {
 			data.Result = "error"
 			data.Message = "Could not parse form data"
@@ -128,8 +159,21 @@ func (f *ForceRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		run.Enqueue(f.RunQueue, run.ForcedRun, waybill)
+		if f.Authenticator != nil {
+			// if the user can patch the Waybill, they are allowed to force a run
+			hasAccess, err := f.KubeClient.HasAccess(r.Context(), waybill, userEmail, "patch")
+			if !hasAccess {
+				data.Result = "error"
+				data.Message = fmt.Sprintf("User %s is not allowed to force a run on waybill %s/%s", userEmail, waybill.Namespace, waybill.Name)
+				if err != nil {
+					log.Logger("webserver").Error(data.Message, "error", err)
+				}
+				w.WriteHeader(http.StatusForbidden)
+				break
+			}
+		}
 
+		run.Enqueue(f.RunQueue, run.ForcedRun, waybill)
 		data.Result = "success"
 		data.Message = "Run queued"
 		w.WriteHeader(http.StatusOK)
@@ -191,11 +235,13 @@ func (ws *WebServer) Start() error {
 	m := mux.NewRouter()
 	addStatusEndpoints(m)
 	statusPageHandler := &StatusPageHandler{
+		ws.Authenticator,
 		ws.Clock,
 		ws.result,
 		template,
 	}
 	forceRunHandler := &ForceRunHandler{
+		ws.Authenticator,
 		ws.KubeClient,
 		ws.RunQueue,
 	}

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -106,14 +106,14 @@ var _ = Describe("WebServer", func() {
 			body, err := io.ReadAll(res.Body)
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
-			Expect(body).To(MatchJSON(`{"result":  "error", "message": "Must be a POST request"}`))
+			Expect(body).To(MatchJSON(`{"result": "error", "message": "must be a POST request"}`))
 
 			res, err = http.PostForm(fmt.Sprintf("http://localhost:%d/api/v1/forceRun", testWebServer.ListenPort), v)
 			Expect(err).To(BeNil())
 			body, err = io.ReadAll(res.Body)
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
-			Expect(body).To(MatchJSON(`{"result":  "error", "message": "Empty namespace value"}`))
+			Expect(body).To(MatchJSON(`{"result": "error", "message": "empty namespace value"}`))
 
 			v.Set("namespace", "invalid")
 			res, err = http.PostForm(fmt.Sprintf("http://localhost:%d/api/v1/forceRun", testWebServer.ListenPort), v)
@@ -121,7 +121,7 @@ var _ = Describe("WebServer", func() {
 			body, err = io.ReadAll(res.Body)
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
-			Expect(body).To(MatchJSON(`{"result":  "error", "message": "Cannot find Waybills in namespace 'invalid'"}`))
+			Expect(body).To(MatchJSON(`{"result": "error", "message": "cannot find Waybills in namespace 'invalid'"}`))
 
 			v.Set("namespace", wbList[0].Namespace)
 			res, err = http.PostForm(fmt.Sprintf("http://localhost:%d/api/v1/forceRun", testWebServer.ListenPort), v)
@@ -129,7 +129,7 @@ var _ = Describe("WebServer", func() {
 			body, err = io.ReadAll(res.Body)
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
-			Expect(body).To(MatchJSON(`{"result":  "success", "message": "Run queued"}`))
+			Expect(body).To(MatchJSON(`{"result": "success", "message": "Run queued"}`))
 
 			testWebServer.Shutdown()
 			close(testRunQueue)


### PR DESCRIPTION
- kube-applier HTTP endpoints are now authenticated (except for meta)
- the user's idToken is used to retrieve their email address, which determines access to force a run
- users who can PATCH Waybills in a namespace can also force a run