### PR TITLE
Ensure counter vectors start with a zero value

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -246,6 +246,17 @@ func ReconcileFromWaybillList(waybills []kubeapplierv1alpha1.Waybill) {
 		lastRunTimestamp.With(prometheus.Labels{
 			"namespace": wb.Namespace,
 		}).Set(float64(wb.Status.LastRun.Finished.Unix()))
+		// Initialise the following vectors, if they don't exist. By simply
+		// fetching an instance of a Counter from the CounterVec, it is being
+		// initialised, if it doesn't exist. This ensures that counters start
+		// with a zero value if they have not been updated before.
+		for _, b := range []string{"true", "false"} {
+			namespaceApplyCount.With(prometheus.Labels{"namespace": wb.Namespace, "success": b})
+			runLatency.With(prometheus.Labels{"namespace": wb.Namespace, "success": b, "dryrun": "true"})
+			runLatency.With(prometheus.Labels{"namespace": wb.Namespace, "success": b, "dryrun": "false"})
+		}
+		kubectlExitCodeCount.With(prometheus.Labels{"namespace": wb.Namespace, "exit_code": "0"})
+		kubectlExitCodeCount.With(prometheus.Labels{"namespace": wb.Namespace, "exit_code": "1"})
 	}
 }
 


### PR DESCRIPTION
On application restart, counter vectors such as the apply count will
only start being exported on the first update, with a value of one. This
can cause issues with graphs missing the reset and initial change. By
fetching the vector the prometheus also initialises it and exports it
with a value of zero, if it does not already exist.