### PR TITLE
update example to use generatorOptions instead of options

### DIFF
--- a/manifests/example/kustomization.yaml
+++ b/manifests/example/kustomization.yaml
@@ -27,5 +27,5 @@ secretGenerator:
     type: Opaque
     files:
       - .strongbox_keyring=secrets/strongbox-keyring
-    options:
-      disableNameSuffixHash: true
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
`options` no longer appears to be valid https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#generatoroptions