### PR TITLE
Release 3.3.3-rc.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN go get -t ./... &&\
   CGO_ENABLED=1 && go test -race -count=1 ./... &&\
   CGO_ENABLED=0 && go build -o /kube-applier -ldflags '-s -w -extldflags "-static"' .
 
-FROM alpine:3.13
+FROM alpine:3.14
 RUN apk --no-cache add git openssh-client tini
 COPY templates/ /templates/
 COPY static/ /static/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+IMAGE := quay.io/utilitywarehouse/kube-applier
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -79,12 +80,10 @@ run:
 	-p 8080:8080 \
 	-ti kube-applier
 
-# Hack to take arguments from command line
-# Usage: `make release 5.5.5`
-# https://stackoverflow.com/questions/6273608/how-to-pass-argument-to-makefile-from-command-line
 release:
-	sed -i 's#utilitywarehouse/kube-applier:.*#utilitywarehouse/kube-applier:$(filter-out $@,$(MAKECMDGOALS))#g' manifests/base/server/kube-applier.yaml
-	sed -i -E 's#kube-applier//manifests/base/(client|cluster|server)\?ref=.*#kube-applier//manifests/base/\1?ref=$(filter-out $@,$(MAKECMDGOALS))#g' README.md manifests/example/kustomization.yaml
-
-%:		# matches any task name
-	@:	# empty recipe = do nothing
+	@sd "$(IMAGE):latest" "$(IMAGE):$(VERSION)" $$(rg -l -- $(IMAGE) manifests/)
+	@git add -- manifests/
+	@git commit -m "Release $(VERSION)"
+	@sd "$(IMAGE):$(VERSION)" "$(IMAGE):latest" $$(rg -l -- "$(IMAGE)" manifests/)
+	@git add -- manifests/
+	@git commit -m "Clean up release $(VERSION)"

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ namespace:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- github.com/utilitywarehouse/kube-applier//manifests/base/server?ref=3.3.2
+- github.com/utilitywarehouse/kube-applier//manifests/base/server?ref=<version>
 ```
 
 and patch as per example: [manifests/example/](manifests/example/)
@@ -230,7 +230,7 @@ cluster-level resources (also see this [section](#resource-pruning) if you are
 using the `pruneClusterResources` attribute):
 
 ```
-github.com/utilitywarehouse/kube-applier//manifests/base/cluster?ref=3.3.2
+github.com/utilitywarehouse/kube-applier//manifests/base/cluster?ref=<version>
 ```
 
 ## Monitoring

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:3.3.2
+          image: quay.io/utilitywarehouse/kube-applier:latest
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:3.3.3-rc.2
+          image: quay.io/utilitywarehouse/kube-applier:latest
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:latest
+          image: quay.io/utilitywarehouse/kube-applier:3.3.3-rc.2
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"

--- a/manifests/example/kustomization.yaml
+++ b/manifests/example/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../base/server
-#  - github.com/utilitywarehouse/kube-applier//manifests/base/server?ref=3.3.2
+#  - github.com/utilitywarehouse/kube-applier//manifests/base/server?ref=<version>
   - ../base/client
-#  - github.com/utilitywarehouse/kube-applier//manifests/base/client?ref=3.3.2
+#  - github.com/utilitywarehouse/kube-applier//manifests/base/client?ref=<version>
 
 resources:
   - kube-applier-ingress.yaml


### PR DESCRIPTION
- Update to alpine 3.14
- Remove explicit versions from documentation and examples, I don't think it's valuable and it adds the burden of having to update it every time we release.
- Modify the release target to update the image tag in the manifests to match the release version and then revert back to latest. This gives us a commit to tag that allows you to pull manifests for a release version but also means that using master as the ref gives you latest.
- Use the process described above to release 3.3.3-rc.2