### PR TITLE
Support shell pattern matching in allowed-namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ Role and a RoleBinding to give `"get"` permission to it.
 If you need to deploy a shared strongbox keyring to use in multiple namespaces,
 the Secret should have an annotation called
 `"kube-applier.io/allowed-namespaces"` which contains a comma-seperated list of
-all the namespaces that are allowed to use it. For example, the following secret
-can be used by namespaces "ns-a", "ns-b" and "ns-c":
+all the namespaces that are allowed to use it.
+
+For example, the following secret can be used by namespaces "ns-a", "ns-b" and
+"ns-c":
 
 ```
 kind: Secret
@@ -120,6 +122,14 @@ stringData:
     - description: mykey
       key-id: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
       key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+
+Each item in the list of allowed namespaces supports [shell pattern
+matching](https://golang.org/pkg/path/#Match), meaning you can grant access to
+namespaces based on naming conventions:
+
+```
+kube-applier.io/allowed-namespaces: "team-a-*, team-b-monitoring"
 ```
 
 The secret containing the strongbox keyring should itself be version controlled
@@ -142,6 +152,7 @@ define a value for `"known_hosts"`. If ommitted, `git` will use `ssh` with
 To use an SSH key for Kustomize bases, the bases should be defined with the
 `ssh://` scheme in `kustomization.yaml` and have a `# kube-applier: key_foobar`
 comment above it. For example:
+
 ```
 bases:
   # https scheme (default if omitted), any SSH keys defined are ignored

--- a/run/runner.go
+++ b/run/runner.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -61,16 +62,12 @@ func checkSecretIsAllowed(waybill *kubeapplierv1alpha1.Waybill, secret *corev1.S
 		return nil
 	}
 	allowedNamespaces := strings.Split(secret.Annotations[secretAllowedNamespacesAnnotation], ",")
-	allowed := false
 	for _, v := range allowedNamespaces {
-		if strings.TrimSpace(v) == waybill.Namespace {
-			allowed = true
-			break
+		if match, _ := path.Match(strings.TrimSpace(v), waybill.Namespace); match {
+			return nil
 		}
 	}
-	if allowed {
-		return nil
-	}
+
 	return fmt.Errorf(`secret "%s/%s" cannot be used in namespace "%s", the namespace must be listed in the '%s' annotation`, secret.Namespace, secret.Name, waybill.Namespace, secretAllowedNamespacesAnnotation)
 }
 

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -677,6 +677,19 @@ deployment.apps/test-deployment created
 						StrongboxKeyringSecretRef: &kubeapplierv1alpha1.ObjectReference{Name: "strongbox", Namespace: "app-d"},
 					},
 				},
+				{
+					TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "app-d",
+						Namespace: "app-d-strongbox-shared-is-allowed",
+					},
+					Spec: kubeapplierv1alpha1.WaybillSpec{
+						AutoApply:                 pointer.BoolPtr(true),
+						Prune:                     pointer.BoolPtr(true),
+						RepositoryPath:            "app-d",
+						StrongboxKeyringSecretRef: &kubeapplierv1alpha1.ObjectReference{Name: "strongbox", Namespace: "app-d"},
+					},
+				},
 			}
 
 			testEnsureWaybills(wbList)
@@ -685,7 +698,7 @@ deployment.apps/test-deployment created
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "strongbox",
 					Namespace:   "app-d",
-					Annotations: map[string]string{secretAllowedNamespacesAnnotation: "app-d-strongbox-shared"},
+					Annotations: map[string]string{secretAllowedNamespacesAnnotation: "app-d-strongbox-shared,app-d-strongbox-shared-is-*"},
 				},
 				StringData: map[string]string{
 					".strongbox_keyring": `keyentries:
@@ -735,6 +748,18 @@ deployment.apps/test-deployment created
 					Type:    PollingRun.String(),
 				},
 				nil,
+				{
+					Command:      "",
+					Commit:       headCommitHash,
+					ErrorMessage: "",
+					Finished:     metav1.Time{},
+					Output: `namespace/app-d unchanged
+deployment.apps/test-deployment created
+`,
+					Started: metav1.Time{},
+					Success: true,
+					Type:    PollingRun.String(),
+				},
 				{
 					Command:      "",
 					Commit:       headCommitHash,


### PR DESCRIPTION
Useful in environments with enforced naming conventions.