### PR TITLE
Request less CPU

### DIFF
--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -59,7 +59,7 @@ spec:
               cpu: 250m
               memory: 256Mi
             limits:
-              cpu: 7000m
+              cpu: 4000m
               memory: 512Mi
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Our new LimitRange allows limiting up to 6 vCPUs