### PR TITLE
Release v3.3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ update-jquery-js:
 	curl -o static/bootstrap/js/jquery.min.js https://code.jquery.com/jquery-3.6.0.min.js
 
 release:
-	@sd "$(IMAGE):latest" "$(IMAGE):$(VERSION)" $$(rg -l -- $(IMAGE) manifests/)
+	@sd "$(IMAGE):master" "$(IMAGE):$(VERSION)" $$(rg -l -- $(IMAGE) manifests/)
 	@git add -- manifests/
 	@git commit -m "Release $(VERSION)"
-	@sd "$(IMAGE):$(VERSION)" "$(IMAGE):latest" $$(rg -l -- "$(IMAGE)" manifests/)
+	@sd "$(IMAGE):$(VERSION)" "$(IMAGE):master" $$(rg -l -- "$(IMAGE)" manifests/)
 	@git add -- manifests/
 	@git commit -m "Clean up release $(VERSION)"

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:master
+          image: quay.io/utilitywarehouse/kube-applier:v3.3.5
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:latest
+          image: quay.io/utilitywarehouse/kube-applier:master
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"

--- a/manifests/base/server/kube-applier.yaml
+++ b/manifests/base/server/kube-applier.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-applier
       containers:
         - name: kube-applier
-          image: quay.io/utilitywarehouse/kube-applier:v3.3.5
+          image: quay.io/utilitywarehouse/kube-applier:master
           env:
             - name: DIFF_URL_FORMAT
               value: "https://github.com/org/repo/commit/%s"


### PR DESCRIPTION
- Use the `master` tag as `latest` no longer tracks the master branch
- Prefix version with `v` as this is what GH actions expects