### PR TITLE
Revert to strongbox 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 RUN apk --no-cache add curl git
 
 ENV \
-  STRONGBOX_VERSION=0.2.1 \
+  STRONGBOX_VERSION=0.2.0 \
   KUBECTL_VERSION=v1.21.0 \
   KUSTOMIZE_VERSION=v3.8.5
 


### PR DESCRIPTION
0.2.1 removes support for v2 headers, which is a breaking change if you are using secrets encrypted with the short-lived v2 header format.

Reverting for now so I can push other changes from 3.3.5 out in a 3.3.6 release.