### PR TITLE
Reenable and fix tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - "master"
+      - "*"
     tags:
       - "v*"
   pull_request:
@@ -20,12 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      #- name: Set up Go
-      #  uses: actions/setup-go@v2
-      #  with:
-      #    go-version: 1.17
-      #- name: Run tests
-      #  run: go get -t ./... && make test
+        with:
+          fetch-depth: 0
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.17-alpine AS build
 
 WORKDIR /src
 
-RUN apk --no-cache add curl git
+RUN apk --no-cache add git gcc make musl-dev curl bash openssh-client
 
 ENV \
   STRONGBOX_VERSION=0.2.0 \
@@ -23,8 +23,9 @@ COPY go.mod go.sum /src/
 RUN go mod download
 
 COPY . /src
-ENV CGO_ENABLED=0
-RUN go build -o /kube-applier .
+RUN go get -t ./... \
+  && make test \
+  && CGO_ENABLED=0 && go build -o /kube-applier .
 
 FROM alpine:3.14
 RUN apk --no-cache add git openssh-client tini


### PR DESCRIPTION
- Build on push to any branch
- Move tests back into the docker build. We need the strongbox binary to
  perform the tests and by doing it in the docker build we're assured
  we're using the same version without having to maintain two separate
  version strings in the Dockerfile and the GH actions config.
- Checkout with depth 0. The tests rely on having history to perform a diff on.