### PR TITLE
webserver: retrieve Waybills on request

### DIFF
--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -57,6 +57,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	testKubeClient.Shutdown()
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/main.go
+++ b/main.go
@@ -22,29 +22,29 @@ import (
 )
 
 var (
-	fDiffURLFormat        = flag.String("diff-url-format", getStringEnv("DIFF_URL_FORMAT", ""), "Used to generate commit links in the status page")
-	fDryRun               = flag.Bool("dry-run", getBoolEnv("DRY_RUN", false), "Whether kube-applier operates in dry-run mode globally")
-	fGitPollWait          = flag.Duration("git-poll-wait", getDurationEnv("GIT_POLL_WAIT", time.Second*5), "How long kube-applier waits before checking for changes in the repository")
-	fGitKnownHostsPath    = flag.String("git-ssh-known-hosts-path", getStringEnv("GIT_KNOWN_HOSTS_PATH", ""), "Path to the known hosts file used for fetching the repository")
-	fGitSSHKeyPath        = flag.String("git-ssh-key-path", getStringEnv("GIT_SSH_KEY_PATH", ""), "Path to the SSH key file used for fetching the repository")
-	fListenPort           = flag.Int("listen-port", getIntEnv("LISTEN_PORT", 8080), "Port that the http server is listening on")
-	fLogLevel             = flag.String("log-level", getStringEnv("LOG_LEVEL", "warn"), "Logging level: trace, debug, info, warn, error, off")
-	fOidcCallbackURL      = flag.String("oidc-callback-url", getStringEnv("OIDC_CALLBACK_URL", ""), "OIDC callback url should be the root URL where kube-applier is exposed")
-	fOidcClientID         = flag.String("oidc-client-id", getStringEnv("OIDC_CLIENT_ID", ""), "Client ID of the OIDC application")
-	fOidcClientSecret     = flag.String("oidc-client-secret", getStringEnv("OIDC_CLIENT_SECRET", ""), "Client secret of the OIDC application")
-	fOidcIssuer           = flag.String("oidc-issuer", getStringEnv("OIDC_ISSUER", ""), "OIDC issuer URL of the authentication server")
-	fPruneBlacklist       = flag.String("prune-blacklist", getStringEnv("PRUNE_BLACKLIST", ""), "Comma-seperated list of resources to add to the global prune blacklist, in the <group>/<version>/<kind> format")
-	fRepoBranch           = flag.String("repo-branch", getStringEnv("REPO_BRANCH", "master"), "Branch of the git repository to use")
-	fRepoDepth            = flag.Int("repo-depth", getIntEnv("REPO_DEPTH", 0), "Depth of the git repository to fetch. Use zero to ignore")
-	fRepoDest             = flag.String("repo-dest", getStringEnv("REPO_DEST", "/src"), "Path under which the the git repository is fetched")
-	fRepoPath             = flag.String("repo-path", getStringEnv("REPO_PATH", ""), "Path relative to the repository root that kube-applier operates in")
-	fRepoRemote           = flag.String("repo-remote", getStringEnv("REPO_REMOTE", ""), "Remote URL of the git repository that kube-applier uses as a source")
-	fRepoRevision         = flag.String("repo-revision", getStringEnv("REPO_REVISION", "HEAD"), "Revision of the git repository to use")
-	fRepoSyncInterval     = flag.Duration("repo-sync-interval", getDurationEnv("REPO_SYNC_INTERVAL", time.Second*30), "How often kube-applier will try to sync the local repository clone to the remote")
-	fRepoTimeout          = flag.Duration("repo-timeout", getDurationEnv("REPO_TIMEOUT", time.Minute*3), "How long kube-applier will wait for the initial repository sync to complete")
-	fStatusUpdateInterval = flag.Duration("status-update-interval", getDurationEnv("STATUS_UPDATE_INTERVAL", time.Minute), "How often the status page updates from the cluster state")
-	fWaybillPollInterval  = flag.Duration("waybill-poll-interval", getDurationEnv("WAYBILL_POLL_INTERVAL", time.Minute), "How often kube-applier updates the Waybills it tracks from the cluster")
-	fWorkerCount          = flag.Int("worker-count", getIntEnv("WORKER_COUNT", 2), "Number of apply worker goroutines that kube-applier uses")
+	fDiffURLFormat       = flag.String("diff-url-format", getStringEnv("DIFF_URL_FORMAT", ""), "Used to generate commit links in the status page")
+	fDryRun              = flag.Bool("dry-run", getBoolEnv("DRY_RUN", false), "Whether kube-applier operates in dry-run mode globally")
+	fGitPollWait         = flag.Duration("git-poll-wait", getDurationEnv("GIT_POLL_WAIT", time.Second*5), "How long kube-applier waits before checking for changes in the repository")
+	fGitKnownHostsPath   = flag.String("git-ssh-known-hosts-path", getStringEnv("GIT_KNOWN_HOSTS_PATH", ""), "Path to the known hosts file used for fetching the repository")
+	fGitSSHKeyPath       = flag.String("git-ssh-key-path", getStringEnv("GIT_SSH_KEY_PATH", ""), "Path to the SSH key file used for fetching the repository")
+	fListenPort          = flag.Int("listen-port", getIntEnv("LISTEN_PORT", 8080), "Port that the http server is listening on")
+	fLogLevel            = flag.String("log-level", getStringEnv("LOG_LEVEL", "warn"), "Logging level: trace, debug, info, warn, error, off")
+	fOidcCallbackURL     = flag.String("oidc-callback-url", getStringEnv("OIDC_CALLBACK_URL", ""), "OIDC callback url should be the root URL where kube-applier is exposed")
+	fOidcClientID        = flag.String("oidc-client-id", getStringEnv("OIDC_CLIENT_ID", ""), "Client ID of the OIDC application")
+	fOidcClientSecret    = flag.String("oidc-client-secret", getStringEnv("OIDC_CLIENT_SECRET", ""), "Client secret of the OIDC application")
+	fOidcIssuer          = flag.String("oidc-issuer", getStringEnv("OIDC_ISSUER", ""), "OIDC issuer URL of the authentication server")
+	fPruneBlacklist      = flag.String("prune-blacklist", getStringEnv("PRUNE_BLACKLIST", ""), "Comma-seperated list of resources to add to the global prune blacklist, in the <group>/<version>/<kind> format")
+	fRepoBranch          = flag.String("repo-branch", getStringEnv("REPO_BRANCH", "master"), "Branch of the git repository to use")
+	fRepoDepth           = flag.Int("repo-depth", getIntEnv("REPO_DEPTH", 0), "Depth of the git repository to fetch. Use zero to ignore")
+	fRepoDest            = flag.String("repo-dest", getStringEnv("REPO_DEST", "/src"), "Path under which the the git repository is fetched")
+	fRepoPath            = flag.String("repo-path", getStringEnv("REPO_PATH", ""), "Path relative to the repository root that kube-applier operates in")
+	fRepoRemote          = flag.String("repo-remote", getStringEnv("REPO_REMOTE", ""), "Remote URL of the git repository that kube-applier uses as a source")
+	fRepoRevision        = flag.String("repo-revision", getStringEnv("REPO_REVISION", "HEAD"), "Revision of the git repository to use")
+	fRepoSyncInterval    = flag.Duration("repo-sync-interval", getDurationEnv("REPO_SYNC_INTERVAL", time.Second*30), "How often kube-applier will try to sync the local repository clone to the remote")
+	fRepoTimeout         = flag.Duration("repo-timeout", getDurationEnv("REPO_TIMEOUT", time.Minute*3), "How long kube-applier will wait for the initial repository sync to complete")
+	fStatusTimeout       = flag.Duration("status-timeout", getDurationEnv("STATUS_TIMEOUT", time.Second*30), "Timeout for retrieving the status UI information from Kubernetes")
+	fWaybillPollInterval = flag.Duration("waybill-poll-interval", getDurationEnv("WAYBILL_POLL_INTERVAL", time.Minute), "How often kube-applier updates the Waybills it tracks from the cluster")
+	fWorkerCount         = flag.Int("worker-count", getIntEnv("WORKER_COUNT", 2), "Number of apply worker goroutines that kube-applier uses")
 )
 
 func getStringEnv(name, defaultValue string) string {
@@ -186,13 +186,13 @@ func main() {
 	scheduler.Start()
 
 	webserver := &webserver.WebServer{
-		Authenticator:        oidcAuthenticator,
-		Clock:                clock,
-		DiffURLFormat:        *fDiffURLFormat,
-		KubeClient:           kubeClient,
-		ListenPort:           *fListenPort,
-		RunQueue:             runQueue,
-		StatusUpdateInterval: *fStatusUpdateInterval,
+		Authenticator: oidcAuthenticator,
+		Clock:         clock,
+		DiffURLFormat: *fDiffURLFormat,
+		KubeClient:    kubeClient,
+		ListenPort:    *fListenPort,
+		RunQueue:      runQueue,
+		StatusTimeout: *fStatusTimeout,
 	}
 	if err := webserver.Start(); err != nil {
 		log.Logger("kube-applier").Error(fmt.Sprintf("Cannot start webserver: %v", err))

--- a/manifests/base/cluster/clusterrole.yaml
+++ b/manifests/base/cluster/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
   - apiGroups: ["kube-applier.io"]
     resources: ["waybills"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
   - apiGroups: ["kube-applier.io"]
     resources: ["waybills/status"]
     verbs: ["update"]

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -446,7 +446,7 @@ N3ZtSHVWd1pXb1JBcGI4bmd4S0EKQUFBRUI1VDBoKzNGV0J0M0xaZXpyL00rZzd5Q2NtaHFjYWRQ
 V0dTRjltUDh1L21mYklCTnBsMjhYMnFnQTQ5bkw3UFJHRwp2dStZZTVYQmxhaEVDbHZ5ZURFb0FB
 QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "git-ssh",
 					Namespace: "app-b-kustomize-noaccess",
@@ -454,7 +454,7 @@ QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 				StringData: map[string]string{"key_random": string(randomKey)},
 				Type:       corev1.SecretTypeOpaque,
 			})).To(BeNil())
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "git-ssh",
 					Namespace: "app-b-kustomize",
@@ -462,7 +462,7 @@ QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 				StringData: map[string]string{"key_deploy": string(deployKey)},
 				Type:       corev1.SecretTypeOpaque,
 			})).To(BeNil())
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "git-ssh",
 					Namespace: "app-b-kustomize-twokeys",
@@ -473,7 +473,7 @@ QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 				},
 				Type: corev1.SecretTypeOpaque,
 			})).To(BeNil())
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "git-ssh",
 					Namespace: "app-c-kustomize-withkey",
@@ -573,7 +573,7 @@ deployment.apps/test-deployment created
 			Eventually(
 				func() error {
 					deployment := &appsv1.Deployment{}
-					return k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "app-c-kustomize-withkey", Name: "test-deployment"}, deployment)
+					return k8sClient.GetAPIReader().Get(context.TODO(), client.ObjectKey{Namespace: "app-c-kustomize-withkey", Name: "test-deployment"}, deployment)
 				},
 				time.Second*120,
 				time.Second,
@@ -698,7 +698,7 @@ deployment.apps/test-deployment created
 
 			testEnsureWaybills(wbList)
 
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "strongbox",
 					Namespace:   "app-d",
@@ -712,7 +712,7 @@ deployment.apps/test-deployment created
 				},
 				Type: corev1.SecretTypeOpaque,
 			})).To(BeNil())
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "strongbox-empty",
 					Namespace: "app-d-empty",
@@ -792,7 +792,7 @@ deployment.apps/test-deployment created
 			Eventually(
 				func() error {
 					deployment := &appsv1.Deployment{}
-					return k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "app-d", Name: "test-deployment"}, deployment)
+					return k8sClient.GetAPIReader().Get(context.TODO(), client.ObjectKey{Namespace: "app-d", Name: "test-deployment"}, deployment)
 				},
 				time.Second*15,
 				time.Second,
@@ -871,13 +871,13 @@ deployment.apps/test-deployment created
 			testEnsureWaybills(wbList)
 
 			// Manipulate the delegate Secrets that have been create above
-			Expect(k8sClient.Delete(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "app-e-notfound", Name: "ka-notfound"}})).To(BeNil())
-			Expect(k8sClient.Delete(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "app-e-wrongtype", Name: "ka-wrongtype"}})).To(BeNil())
-			Expect(k8sClient.Create(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Delete(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "app-e-notfound", Name: "ka-notfound"}})).To(BeNil())
+			Expect(k8sClient.GetClient().Delete(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "app-e-wrongtype", Name: "ka-wrongtype"}})).To(BeNil())
+			Expect(k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "app-e-wrongtype", Name: "ka-wrongtype"},
 				Type:       corev1.SecretTypeOpaque,
 			})).To(BeNil())
-			Expect(k8sClient.Update(context.TODO(), &corev1.Secret{
+			Expect(k8sClient.GetClient().Update(context.TODO(), &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace:   "app-e-notoken",
 					Name:        "ka-notoken",
@@ -923,7 +923,7 @@ deployment.apps/test-deployment created
 			Eventually(
 				func() error {
 					deployment := &appsv1.Deployment{}
-					return k8sClient.Get(context.TODO(), client.ObjectKey{Namespace: "app-e", Name: "test-deployment"}, deployment)
+					return k8sClient.GetAPIReader().Get(context.TODO(), client.ObjectKey{Namespace: "app-e", Name: "test-deployment"}, deployment)
 				},
 				time.Second*15,
 				time.Second,

--- a/run/scheduler_test.go
+++ b/run/scheduler_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Scheduler", func() {
 				},
 			}
 			// remove the "bar" Waybill
-			k8sClient.Delete(context.TODO(), wbList[len(wbList)-1])
+			k8sClient.GetClient().Delete(context.TODO(), wbList[len(wbList)-1])
 			wbList = wbList[:len(wbList)-1]
 			testEnsureWaybills(wbList)
 			testWaitForSchedulerToUpdate(&testScheduler, wbList)
@@ -352,7 +352,7 @@ Some error output has been omitted because it may contain sensitive data
 
 func testEnsureWaybills(wbList []*kubeapplierv1alpha1.Waybill) {
 	for i := range wbList {
-		err := k8sClient.Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wbList[i].Namespace}})
+		err := k8sClient.GetClient().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wbList[i].Namespace}})
 		if err != nil && !errors.IsAlreadyExists(err) {
 			Expect(err).To(BeNil())
 		}
@@ -360,7 +360,7 @@ func testEnsureWaybills(wbList []*kubeapplierv1alpha1.Waybill) {
 		// Create() which makes it difficult to handle it below.
 		rv := wbList[i].ResourceVersion
 		wbList[i].ResourceVersion = ""
-		err = k8sClient.Create(context.TODO(), wbList[i])
+		err = k8sClient.GetClient().Create(context.TODO(), wbList[i])
 		if err != nil && errors.IsAlreadyExists(err) {
 			wbList[i].ResourceVersion = rv
 			Expect(k8sClient.UpdateWaybill(context.TODO(), wbList[i])).To(BeNil())
@@ -382,7 +382,7 @@ func testEnsureWaybills(wbList []*kubeapplierv1alpha1.Waybill) {
 		_, err = k8sClient.GetSecret(context.TODO(), wbList[i].Namespace, wbList[i].Spec.DelegateServiceAccountSecretRef)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				err = k8sClient.Create(context.TODO(), &corev1.Secret{
+				err = k8sClient.GetClient().Create(context.TODO(), &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      wbList[i].Spec.DelegateServiceAccountSecretRef,
 						Namespace: wbList[i].Namespace,

--- a/webserver/result.go
+++ b/webserver/result.go
@@ -3,7 +3,6 @@ package webserver
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,10 +11,10 @@ import (
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 )
 
-// Result stores the data from a single run of the apply loop.
-// The functions associated with Result convert raw data into the desired formats for insertion into the status page template.
+// Result stores the current state of the waybills  The functions associated
+// with Result convert raw data into the desired formats
+// for insertion into the status page template.
 type Result struct {
-	*sync.Mutex
 	Waybills      []kubeapplierv1alpha1.Waybill
 	DiffURLFormat string
 }
@@ -23,8 +22,6 @@ type Result struct {
 // Successes returns all the Waybills that applied successfully.
 func (r *Result) Successes() []kubeapplierv1alpha1.Waybill {
 	var ret []kubeapplierv1alpha1.Waybill
-	r.Lock()
-	defer r.Unlock()
 	for _, wb := range r.Waybills {
 		if wb.Status.LastRun != nil && wb.Status.LastRun.Success {
 			ret = append(ret, wb)
@@ -36,8 +33,6 @@ func (r *Result) Successes() []kubeapplierv1alpha1.Waybill {
 // Failures returns all the Waybills that failed applying.
 func (r *Result) Failures() []kubeapplierv1alpha1.Waybill {
 	var ret []kubeapplierv1alpha1.Waybill
-	r.Lock()
-	defer r.Unlock()
 	for _, wb := range r.Waybills {
 		if wb.Status.LastRun != nil && !wb.Status.LastRun.Success {
 			ret = append(ret, wb)
@@ -67,8 +62,6 @@ func (r *Result) CommitLink(commit string) string {
 
 // Finished returns true if the Result is from a finished apply run.
 func (r *Result) Finished() bool {
-	r.Lock()
-	defer r.Unlock()
 	return len(r.Waybills) > 0
 }
 

--- a/webserver/result_test.go
+++ b/webserver/result_test.go
@@ -1,7 +1,6 @@
 package webserver
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -36,7 +35,7 @@ var formattingTestCasess = []formattingTestCases{
 
 func TestResultFormattedTime(t *testing.T) {
 	assert := assert.New(t)
-	r := Result{Mutex: &sync.Mutex{}}
+	r := Result{}
 	for _, tc := range formattingTestCasess {
 		status := kubeapplierv1alpha1.WaybillStatusRun{
 			Started:  metav1.NewTime(tc.Start),
@@ -48,7 +47,7 @@ func TestResultFormattedTime(t *testing.T) {
 
 func TestResultLatency(t *testing.T) {
 	assert := assert.New(t)
-	r := Result{Mutex: &sync.Mutex{}}
+	r := Result{}
 	for _, tc := range formattingTestCasess {
 		status := kubeapplierv1alpha1.WaybillStatusRun{
 			Started:  metav1.NewTime(tc.Start),
@@ -111,7 +110,7 @@ var totalFilesTestCases = []totalFilesTestCase{
 func TestResultSuccessesAndFailures(t *testing.T) {
 	assert := assert.New(t)
 	for _, tc := range totalFilesTestCases {
-		r := Result{Mutex: &sync.Mutex{}, Waybills: tc.Waybills}
+		r := Result{Waybills: tc.Waybills}
 		assert.Equal(tc.Successes, r.Successes())
 		assert.Equal(tc.Failures, r.Failures())
 	}
@@ -145,20 +144,20 @@ var lastCommitLinkTestCases = []lastCommitLinkTestCase{
 func TestResultLastCommitLink(t *testing.T) {
 	assert := assert.New(t)
 	for _, tc := range lastCommitLinkTestCases {
-		r := Result{Mutex: &sync.Mutex{}, DiffURLFormat: tc.DiffURLFormat}
+		r := Result{DiffURLFormat: tc.DiffURLFormat}
 		assert.Equal(tc.ExpectedLink, r.CommitLink(tc.CommitHash))
 	}
 }
 
 func TestResultFinished(t *testing.T) {
 	assert := assert.New(t)
-	r := Result{Mutex: &sync.Mutex{}}
+	r := Result{}
 	assert.Equal(r.Finished(), false)
 	r.Waybills = []kubeapplierv1alpha1.Waybill{{}}
 	assert.Equal(r.Finished(), true)
 
 	for _, tc := range lastCommitLinkTestCases {
-		r := Result{Mutex: &sync.Mutex{}, DiffURLFormat: tc.DiffURLFormat}
+		r := Result{DiffURLFormat: tc.DiffURLFormat}
 		assert.Equal(tc.ExpectedLink, r.CommitLink(tc.CommitHash))
 	}
 }
@@ -205,7 +204,7 @@ func TestResultAppliedRecently(t *testing.T) {
 		},
 	}
 
-	r := Result{Mutex: &sync.Mutex{}}
+	r := Result{}
 
 	assert.Equal(false, r.AppliedRecently(kubeapplierv1alpha1.Waybill{}))
 

--- a/webserver/suite_test.go
+++ b/webserver/suite_test.go
@@ -59,6 +59,7 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
+	testKubeClient.Shutdown()
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -47,13 +47,13 @@ var _ = Describe("WebServer", func() {
 		testRunQueue = make(chan run.Request)
 		testWebServerRequests = testWebServerDrainRequests(testRunQueue)
 		testWebServer = WebServer{
-			ListenPort:           35432,
-			Clock:                &zeroClock{},
-			DiffURLFormat:        "http://foo.bar/diff/%s",
-			KubeClient:           testKubeClient,
-			RunQueue:             testRunQueue,
-			StatusUpdateInterval: time.Second * 5,
-			TemplatePath:         "../templates/status.html",
+			ListenPort:    35432,
+			Clock:         &zeroClock{},
+			DiffURLFormat: "http://foo.bar/diff/%s",
+			KubeClient:    testKubeClient,
+			RunQueue:      testRunQueue,
+			StatusTimeout: time.Second * 5,
+			TemplatePath:  "../templates/status.html",
 		}
 		Expect(testWebServer.Start()).To(BeNil())
 	})
@@ -76,30 +76,9 @@ var _ = Describe("WebServer", func() {
 			},
 		}
 
-		It("Should keep track of Waybill resources on the server", func() {
-			By("Listing all the Waybills in the cluster")
-			testEnsureWaybills(wbList)
-			Eventually(
-				func() []kubeapplierv1alpha1.Waybill {
-					testWebServer.result.Lock()
-					defer testWebServer.result.Unlock()
-					ret := make([]kubeapplierv1alpha1.Waybill, len(testWebServer.result.Waybills))
-					for i := range testWebServer.result.Waybills {
-						ret[i] = testWebServer.result.Waybills[i]
-					}
-					return ret
-				},
-				time.Second*15,
-				time.Second,
-			).Should(ConsistOf(wbList))
-
-			testWebServer.Shutdown()
-			close(testRunQueue)
-
-			Expect(testWebServerRequests()).To(Equal([]run.Request{}))
-		})
-
 		It("Should trigger a ForcedRun when a valid request is made", func() {
+			testEnsureWaybills(wbList)
+
 			v := url.Values{}
 			res, err := http.Get(fmt.Sprintf("http://localhost:%d/api/v1/forceRun", testWebServer.ListenPort))
 			Expect(err).To(BeNil())

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -150,7 +150,7 @@ var _ = Describe("WebServer", func() {
 // instead of pointers), can we share?
 func testEnsureWaybills(wbList []kubeapplierv1alpha1.Waybill) {
 	for i := range wbList {
-		err := testKubeClient.Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wbList[i].Namespace}})
+		err := testKubeClient.GetClient().Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wbList[i].Namespace}})
 		if err != nil {
 			Expect(errors.IsAlreadyExists(err)).To(BeTrue())
 		}
@@ -158,7 +158,7 @@ func testEnsureWaybills(wbList []kubeapplierv1alpha1.Waybill) {
 		// Create() which makes it difficult to handle it below.
 		rv := wbList[i].ResourceVersion
 		wbList[i].ResourceVersion = ""
-		err = testKubeClient.Create(context.TODO(), &wbList[i])
+		err = testKubeClient.GetClient().Create(context.TODO(), &wbList[i])
 		if err != nil && errors.IsAlreadyExists(err) {
 			wbList[i].ResourceVersion = rv
 			Expect(testKubeClient.UpdateWaybill(context.TODO(), &wbList[i])).To(BeNil())


### PR DESCRIPTION
The webserver polls the apiserver every minute and maintains a cache of the Waybill status. This minute-long delay on the status being updated can be quite frustrating when you're force-running things and waiting for results to appear. Especially when controller-runtime and client-go already provide more responsive ways to cache objects using list/watch.

This PR modifies the webserver so that it lists the waybills for every request to the status page, meaning that the information provided matches the state in the kube cluster.

To facilitate this and to keep latency and requests to the apiserver low, I've replaced the controller-runtime client we were using with the default one, which reads from a cache and writes directly to the API server. The cache is populated by a watch.

I think this is better for a number of reasons:
- The status UI is up-to-date
- Overall there should be less direct requests to the API server
- The webserver code is less complicated without all the locking and mutexes

The controller-runtime also provides it's own event broadcaster, which I've opted to use vs setting our own up. It makes sense to me to stick to the framework unless we have a good reason not to.

