### PR TITLE
webserver: add panel for Waybills without a last run

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -16,6 +16,71 @@
         <div class="col-md-4"></div>
         <div id="force-alert-container" class="col-md-4"></div>
     </div>
+    {{ if .Pending }}
+    <div class="row">
+        <div class="col-md-2"></div>
+        <div class="col-md-8">
+            <div class="panel-group">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4 class="panel-title">
+                            <a data-toggle="collapse" href="#pending">Pending: {{ len .Pending }}</a>
+                        </h4>
+                    </div>
+                    <div id="pending" class="panel-group collapse in">
+                        {{ range $i, $wb := .Pending }}
+                        <div class="panel">
+                            <div class="panel-heading">
+                                <div class="panel-title">
+                                    <a data-toggle="collapse" href="#pending-{{$i}}">{{ $wb.Namespace }} {{ $.Status $wb }}</a>
+                                </div>
+                            </div>
+                            <div id="pending-{{$i}}" class="panel-collapse collapse">
+                                <ul class="list-group">
+                                    <li class="list-group-item">
+                                        <div class="row">
+                                            <div class="col-md-10">
+                                              <strong>Created at:</strong> {{ $wb.CreationTimestamp }}
+                                            </div>
+                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+                                        </div>
+                                    </li>
+                                    {{ if $.WaybillEvents $wb }}
+                                    <li class="list-group-item">
+                                      <table class="table">
+                                        <thead>
+                                            <tr>
+                                            <th scope="col">LAST SEEN</th>
+                                            <th scope="col">TYPE</th>
+                                            <th scope="col">REASON</th>
+                                            <th scope="col">MESSAGE</th>
+                                           </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{ range $i, $e := $.WaybillEvents $wb }}
+                                        {{ if eq $e.Namespace $wb.Namespace }}
+                                          <tr>
+                                            <td>{{ $e.LastTimestamp }}</th>
+                                            <td>{{ $e.Type }}</td>
+                                            <td>{{ $e.Reason }}</td>
+                                            <td>{{ $e.Message }}</td>
+                                         </tr>
+                                        {{ end }}
+                                        {{ end }}
+                                        </tbody>
+                                     </table>
+                                  </li>
+                                  {{ end }}
+                                </ul>
+                            </div>
+                        </div>
+                        {{ end }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {{ end }}
     <div class="row">
         <div class="col-md-2"></div>
         <div class="col-md-8">
@@ -49,6 +114,32 @@
                                     <li class="list-group-item">
                                         <pre class="file-output">{{ printf "$ %s\n" $wb.Status.LastRun.Command }}{{ $wb.Status.LastRun.Output }}{{ $wb.Status.LastRun.ErrorMessage }}</pre>
                                     </li>
+                                    {{ if $.WaybillEvents $wb }}
+                                    <li class="list-group-item">
+                                      <table class="table">
+                                        <thead>
+                                            <tr>
+                                            <th scope="col">LAST SEEN</th>
+                                            <th scope="col">TYPE</th>
+                                            <th scope="col">REASON</th>
+                                            <th scope="col">MESSAGE</th>
+                                           </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{ range $i, $e := $.WaybillEvents $wb }}
+                                        {{ if eq $e.Namespace $wb.Namespace }}
+                                          <tr>
+                                            <td>{{ $e.LastTimestamp }}</th>
+                                            <td>{{ $e.Type }}</td>
+                                            <td>{{ $e.Reason }}</td>
+                                            <td>{{ $e.Message }}</td>
+                                         </tr>
+                                        {{ end }}
+                                        {{ end }}
+                                        </tbody>
+                                     </table>
+                                  </li>
+                                  {{ end }}
                                 </ul>
                             </div>
                         </div>
@@ -91,6 +182,32 @@
                                     <li class="list-group-item">
                                         <pre class="file-output">{{ printf "$ %s\n" $wb.Status.LastRun.Command }}{{ $wb.Status.LastRun.Output }}</pre>
                                     </li>
+                                    {{ if $.WaybillEvents $wb }}
+                                    <li class="list-group-item">
+                                      <table class="table">
+                                        <thead>
+                                            <tr>
+                                            <th scope="col">LAST SEEN</th>
+                                            <th scope="col">TYPE</th>
+                                            <th scope="col">REASON</th>
+                                            <th scope="col">MESSAGE</th>
+                                           </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{ range $i, $e := $.WaybillEvents $wb }}
+                                        {{ if eq $e.Namespace $wb.Namespace }}
+                                          <tr>
+                                            <td>{{ $e.LastTimestamp }}</th>
+                                            <td>{{ $e.Type }}</td>
+                                            <td>{{ $e.Reason }}</td>
+                                            <td>{{ $e.Message }}</td>
+                                         </tr>
+                                        {{ end }}
+                                        {{ end }}
+                                        </tbody>
+                                     </table>
+                                  </li>
+                                  {{ end }}
                                 </ul>
                             </div>
                         </div>

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -80,8 +80,15 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Logger("webserver").Error("Unable to list Waybill resources", "error", err, "time", s.Clock.Now().String())
 		return
 	}
+	events, err := s.KubeClient.ListWaybillEvents(ctx)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Error: Unable to list Waybill events: %v", err), http.StatusInternalServerError)
+		log.Logger("webserver").Error("Unable to list Waybill events", "error", err, "time", s.Clock.Now().String())
+		return
+	}
 	result := &Result{
 		DiffURLFormat: s.DiffURLFormat,
+		Events:        events,
 		Waybills:      waybills,
 	}
 	rendered := &bytes.Buffer{}


### PR DESCRIPTION
A new Waybill won't appear on the UI if there's some kind of setup error (i.e a problem fetching the delegate secret) or if it's created with `autoApply: false` because there's no 'LastRun' status field.

I've had a few reports from users where this has created confusion, so I've added a panel that shows 'Pending' Waybills that are yet to have their first run.

In addition to this, I've also added events to the UI, which should give users a decent amount of context to help them understand what's going wrong and maybe fix it themselves without having to contact us.

The page loads with the panels collapsed, like so:
![Screenshot from 2021-09-10 08-31-26](https://user-images.githubusercontent.com/9870923/132818418-e3a3473e-bcba-4eb8-8b79-5cb0849fe7ed.png)

When expanded it looks like:
![Screenshot from 2021-09-10 08-31-41](https://user-images.githubusercontent.com/9870923/132818427-44945439-dbfa-4a81-b7f2-1da68636422e.png)

