### PR TITLE
Display request failures as errors in the status page

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -105,15 +105,17 @@
                                         <div class="row">
                                             <div class="col-md-10">
                                                 <strong>Type: </strong>{{ $wb.Status.LastRun.Type }}<br/>
-                                                <strong>Commit: </strong>{{ if $.CommitLink $wb.Status.LastRun.Commit }}<a href="{{ $.CommitLink $wb.Status.LastRun.Commit }}">{{ $wb.Status.LastRun.Commit }}</a>{{ else }}{{ $wb.Status.LastRun.Commit }}{{ end }}<br/>
+                                                {{ if $wb.Status.LastRun.Commit }}<strong>Commit: </strong>{{ if $.CommitLink $wb.Status.LastRun.Commit }}<a href="{{ $.CommitLink $wb.Status.LastRun.Commit }}">{{ $wb.Status.LastRun.Commit }}</a>{{ else }}{{ $wb.Status.LastRun.Commit }}{{ end }}{{ end }}<br/>
                                                 <strong>Started: </strong>{{ $.FormattedTime $wb.Status.LastRun.Started }} (took {{ $.Latency $wb.Status.LastRun.Started $wb.Status.LastRun.Finished }})
                                             </div>
                                             <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
                                         </div>
                                     </li>
+				    {{ if $wb.Status.LastRun.Command }}
                                     <li class="list-group-item">
                                         <pre class="file-output">{{ printf "$ %s\n" $wb.Status.LastRun.Command }}{{ $wb.Status.LastRun.Output }}{{ $wb.Status.LastRun.ErrorMessage }}</pre>
                                     </li>
+				    {{ end }}
                                     {{ if $.WaybillEvents $wb }}
                                     <li class="list-group-item">
                                       <table class="table">
@@ -153,7 +155,7 @@
         <div class="col-md-2"></div>
         <div class="col-md-8">
             <div class="panel-group">
-                <div class="panel panel-default {{ if .Failures }}panel-warning{{ else }}panel-success{{ end }}">
+                <div class="panel panel-default panel-success">
                     <div class="panel-heading">
                         <h4 class="panel-title">
                             <a data-toggle="collapse" href="#successes">Applied Namespaces: {{ len .Successes }} / {{ len .Waybills }}</a>


### PR DESCRIPTION
When a request fails before the `kubectl apply` phase we should still chnage the
Waybill.Status.LastRun.Success to mark it as a failure and display it as such
in the status page.
This will produce a failed run for such cases, with empty vaules on fiels
populated after `kubectl apply`. The status page should omit commit row and
outputs if not specified.
Also, we should always default to a "green" panel for successfully applied
namespaces.

Example waybill status after request failure:
```
status:
  lastRun:
    command: ""
    commit: ""
    errorMessage: 'failed fetching delegate token: secrets "kube-applier-delegate-token"
      not found'
    finished: "2022-04-08T15:06:01Z"
    output: ""
    started: "2022-04-08T15:06:01Z"
    success: false
    type: Forced run
```
Example waybill error from UI:
![kube-applier-example](https://user-images.githubusercontent.com/35731697/162470485-f270d934-ea4b-4081-8beb-ce60c35d8163.png)
