### PR TITLE
add warning, DryRun and AutoApply Disabled sections on status page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/go-test/deep v1.0.5
+	github.com/google/go-cmp v0.5.8
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/hashicorp/go-hclog v1.1.0
@@ -34,7 +35,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
@@ -796,7 +796,6 @@ golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpd
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -1,13 +1,23 @@
-pre.file-output {
+.file-output {
+	display: block;
+	padding: 10px;
+	margin: 0 0 10px;
+	color: #333;
+	background-color: #f5f5f5;
+	border: 1px solid #ccc;
+	border-radius: 4px;
 	font-family: Monaco;
 	font-size: 10px;
+	white-space: nowrap;
+	overflow: scroll;
 }
 
 pre.commit {
 	font-size: 12px;
 }
 
-#successes>.panel:nth-of-type(odd), #failures>.panel:nth-of-type(odd) {
+
+.panel:nth-of-type(odd) {
 	background-color: #f9f9f9;
 }
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -56,29 +56,29 @@
     <div class="col-md-2"></div>
     <div class="col-md-8">
         <div class="panel-group">
-            <div class='panel panel-default {{if eq $.Outcome "success"}}panel-success{{else if eq $.Outcome "failure"}}panel-danger{{else if eq $.Outcome "warning"}}panel-warning{{end}}'>
+            <div class='panel panel-default {{if eq $.FilteredBy "success"}}panel-success{{else if eq $.FilteredBy "failure"}}panel-danger{{else if eq $.FilteredBy "warning"}}panel-warning{{end}}'>
                 <div class="panel-heading">
                     <h4 class="panel-title">
-                        <a data-toggle="collapse" href="#{{$.Outcome}}">
-                            {{if eq $.Outcome "pending"}}
+                        <a data-toggle="collapse" href="#{{$.FilteredBy}}">
+                            {{if eq $.FilteredBy "pending"}}
                                 Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "auto-apply-disabled"}}
+                            {{else if eq $.FilteredBy "auto-apply-disabled"}}
                                 Auto Apply Disabled Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "dry-run"}}
+                            {{else if eq $.FilteredBy "dry-run"}}
                                 Dry Run Only Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "pending"}}
+                            {{else if eq $.FilteredBy "pending"}}
                                 Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "failure"}}
+                            {{else if eq $.FilteredBy "failure"}}
                                 Failed Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "warning"}}
+                            {{else if eq $.FilteredBy "warning"}}
                                 Applied Namespaces (with warning): {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.Outcome "success"}}
+                            {{else if eq $.FilteredBy "success"}}
                                 Applied Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{end}}
                         </a>
                     </h4>
                 </div>
-                <div id="{{$.Outcome}}" class="panel-group collapse in">
+                <div id="{{$.FilteredBy}}" class="panel-group collapse in">
                     {{ range $wb :=  .Namespaces }}
                         {{template "namespace" $wb}}
                     {{ end }}

--- a/templates/status.html
+++ b/templates/status.html
@@ -21,6 +21,14 @@
         {{ if (filter . "pending").Namespaces }}
             {{template "section" (filter . "pending")}}
         {{ end }}
+
+        {{ if (filter . "auto-apply-disabled").Namespaces }}
+            {{template "section" (filter . "auto-apply-disabled")}}
+        {{ end }}
+
+        {{ if (filter . "dry-run").Namespaces }}
+            {{template "section" (filter . "dry-run")}}
+        {{ end }}
         
         {{ if (filter . "failure").Namespaces }}
             {{template "section" (filter . "failure")}}
@@ -53,6 +61,12 @@
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#{{$.Outcome}}">
                             {{if eq $.Outcome "pending"}}
+                                Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "auto-apply-disabled"}}
+                                Auto Apply Disabled Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "dry-run"}}
+                                Dry Run Only Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "pending"}}
                                 Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.Outcome "failure"}}
                                 Failed Namespaces: {{ len .Namespaces }} / {{ .Total }}

--- a/templates/status.html
+++ b/templates/status.html
@@ -106,7 +106,12 @@
           </li>
           {{ if .Waybill.Status.LastRun.Command }}
           <li class="list-group-item">
-              <pre class="file-output">{{ printf "$ %s\n" .Waybill.Status.LastRun.Command }}{{ .Waybill.Status.LastRun.Output }}</pre>
+              <div class="file-output">
+                  <div>{{ printf "$ %s\n" .Waybill.Status.LastRun.Command }}</div>
+                  {{ range  $l := splitByNewline .Waybill.Status.LastRun.Output }}
+                  <div{{if getOutputClass $l}} class="{{getOutputClass $l}}"{{ end }}>{{$l}}</div>
+                  {{ end }}
+               </div>
           </li>
           {{ end }}
           {{ if .Events }}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,3 +1,4 @@
+{{define "index"}}
 <!doctype html>
 <html>
 <head>
@@ -11,217 +12,130 @@
 </head>
 <body>
     <h1 class="text-center">kube-applier</h1>
-    {{ if .Finished }}
-    <div class="row">
-        <div class="col-md-4"></div>
-        <div id="force-alert-container" class="col-md-4"></div>
-    </div>
-    {{ if .Pending }}
-    <div class="row">
-        <div class="col-md-2"></div>
-        <div class="col-md-8">
-            <div class="panel-group">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a data-toggle="collapse" href="#pending">Pending: {{ len .Pending }}</a>
-                        </h4>
-                    </div>
-                    <div id="pending" class="panel-group collapse in">
-                        {{ range $i, $wb := .Pending }}
-                        <div class="panel">
-                            <div class="panel-heading">
-                                <div class="panel-title">
-                                    <a data-toggle="collapse" href="#pending-{{$i}}">{{ $wb.Namespace }} {{ $.Status $wb }}</a>
-                                </div>
-                            </div>
-                            <div id="pending-{{$i}}" class="panel-collapse collapse">
-                                <ul class="list-group">
-                                    <li class="list-group-item">
-                                        <div class="row">
-                                            <div class="col-md-10">
-                                              <strong>Created at:</strong> {{ $wb.CreationTimestamp }}
-                                            </div>
-                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
-                                        </div>
-                                    </li>
-                                    {{ if $.WaybillEvents $wb }}
-                                    <li class="list-group-item">
-                                      <table class="table">
-                                        <thead>
-                                            <tr>
-                                            <th scope="col">LAST SEEN</th>
-                                            <th scope="col">TYPE</th>
-                                            <th scope="col">REASON</th>
-                                            <th scope="col">MESSAGE</th>
-                                           </tr>
-                                        </thead>
-                                        <tbody>
-                                        {{ range $i, $e := $.WaybillEvents $wb }}
-                                        {{ if eq $e.Namespace $wb.Namespace }}
-                                          <tr>
-                                            <td>{{ $e.LastTimestamp }}</th>
-                                            <td>{{ $e.Type }}</td>
-                                            <td>{{ $e.Reason }}</td>
-                                            <td>{{ $e.Message }}</td>
-                                         </tr>
-                                        {{ end }}
-                                        {{ end }}
-                                        </tbody>
-                                     </table>
-                                  </li>
-                                  {{ end }}
-                                </ul>
-                            </div>
-                        </div>
-                        {{ end }}
-                    </div>
-                </div>
-            </div>
+    {{ if . }}
+        <div class="row">
+            <div class="col-md-4"></div>
+            <div id="force-alert-container" class="col-md-4"></div>
         </div>
-    </div>
-    {{ end }}
-    <div class="row">
-        <div class="col-md-2"></div>
-        <div class="col-md-8">
-            <div class="panel-group">
-                <div class="panel panel-default {{ if .Failures }}panel-danger{{ else }}panel-success{{ end }}">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a data-toggle="collapse" href="#failures">Errors: {{ len .Failures }}</a>
-                        </h4>
-                    </div>
-                    <div id="failures" class="panel-group collapse {{ if .Failures }}in{{ end }}">
-                        {{ range $i, $wb := .Failures }}
-                        <div class="panel">
-                            <div class="panel-heading">
-                                <div class="panel-title">
-                                    <a data-toggle="collapse" href="#failure-{{$i}}">{{ $wb.Namespace }} {{ $.Status $wb }}</a>
-                                </div>
-                            </div>
-                            <div id="failure-{{$i}}" class="panel-collapse collapse in">
-                                <ul class="list-group">
-                                    <li class="list-group-item">
-                                        <div class="row">
-                                            <div class="col-md-10">
-                                                <strong>Type: </strong>{{ $wb.Status.LastRun.Type }}<br/>
-                                                {{ if $wb.Status.LastRun.Commit }}<strong>Commit: </strong>{{ if $.CommitLink $wb.Status.LastRun.Commit }}<a href="{{ $.CommitLink $wb.Status.LastRun.Commit }}">{{ $wb.Status.LastRun.Commit }}</a>{{ else }}{{ $wb.Status.LastRun.Commit }}{{ end }}{{ end }}<br/>
-                                                <strong>Started: </strong>{{ $.FormattedTime $wb.Status.LastRun.Started }} (took {{ $.Latency $wb.Status.LastRun.Started $wb.Status.LastRun.Finished }})
-                                            </div>
-                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
-                                        </div>
-                                    </li>
-				    {{ if $wb.Status.LastRun.Command }}
-                                    <li class="list-group-item">
-                                        <pre class="file-output">{{ printf "$ %s\n" $wb.Status.LastRun.Command }}{{ $wb.Status.LastRun.Output }}{{ $wb.Status.LastRun.ErrorMessage }}</pre>
-                                    </li>
-				    {{ end }}
-                                    {{ if $.WaybillEvents $wb }}
-                                    <li class="list-group-item">
-                                      <table class="table">
-                                        <thead>
-                                            <tr>
-                                            <th scope="col">LAST SEEN</th>
-                                            <th scope="col">TYPE</th>
-                                            <th scope="col">REASON</th>
-                                            <th scope="col">MESSAGE</th>
-                                           </tr>
-                                        </thead>
-                                        <tbody>
-                                        {{ range $i, $e := $.WaybillEvents $wb }}
-                                        {{ if eq $e.Namespace $wb.Namespace }}
-                                          <tr>
-                                            <td>{{ $e.LastTimestamp }}</th>
-                                            <td>{{ $e.Type }}</td>
-                                            <td>{{ $e.Reason }}</td>
-                                            <td>{{ $e.Message }}</td>
-                                         </tr>
-                                        {{ end }}
-                                        {{ end }}
-                                        </tbody>
-                                     </table>
-                                  </li>
-                                  {{ end }}
-                                </ul>
-                            </div>
-                        </div>
-                        {{ end }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-2"></div>
-        <div class="col-md-8">
-            <div class="panel-group">
-                <div class="panel panel-default panel-success">
-                    <div class="panel-heading">
-                        <h4 class="panel-title">
-                            <a data-toggle="collapse" href="#successes">Applied Namespaces: {{ len .Successes }} / {{ len .Waybills }}</a>
-                        </h4>
-                    </div>
-                    <div id="successes" class="panel-group collapse in">
-                        {{ range $i, $wb := .Successes }}
-                        <div class="panel">
-                            <div class="panel-heading">
-                                <div class="panel-title">
-                                    <a data-toggle="collapse" href="#success-{{$i}}">{{ $wb.Namespace }} {{ $.Status $wb }}</a>
-                                </div>
-                            </div>
-                            <div id="success-{{$i}}" class="panel-collapse collapse {{ if $.AppliedRecently $wb }}in{{ end }}">
-                                <ul class="list-group">
-                                    <li class="list-group-item">
-                                        <div class="row">
-                                            <div class="col-md-10">
-                                                <strong>Type: </strong>{{ $wb.Status.LastRun.Type }}<br/>
-                                                <strong>Commit: </strong>{{ if $.CommitLink $wb.Status.LastRun.Commit }}<a href="{{ $.CommitLink $wb.Status.LastRun.Commit }}">{{ $wb.Status.LastRun.Commit }}</a>{{ else }}{{ $wb.Status.LastRun.Commit }}{{ end }}<br/>
-                                                <strong>Started: </strong>{{ $.FormattedTime $wb.Status.LastRun.Started }} (took {{ $.Latency $wb.Status.LastRun.Started $wb.Status.LastRun.Finished }})
-                                            </div>
-                                            <div class="col-md-2"><button data-namespace="{{ $wb.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
-                                        </div>
-                                    </li>
-                                    <li class="list-group-item">
-                                        <pre class="file-output">{{ printf "$ %s\n" $wb.Status.LastRun.Command }}{{ $wb.Status.LastRun.Output }}</pre>
-                                    </li>
-                                    {{ if $.WaybillEvents $wb }}
-                                    <li class="list-group-item">
-                                      <table class="table">
-                                        <thead>
-                                            <tr>
-                                            <th scope="col">LAST SEEN</th>
-                                            <th scope="col">TYPE</th>
-                                            <th scope="col">REASON</th>
-                                            <th scope="col">MESSAGE</th>
-                                           </tr>
-                                        </thead>
-                                        <tbody>
-                                        {{ range $i, $e := $.WaybillEvents $wb }}
-                                        {{ if eq $e.Namespace $wb.Namespace }}
-                                          <tr>
-                                            <td>{{ $e.LastTimestamp }}</th>
-                                            <td>{{ $e.Type }}</td>
-                                            <td>{{ $e.Reason }}</td>
-                                            <td>{{ $e.Message }}</td>
-                                         </tr>
-                                        {{ end }}
-                                        {{ end }}
-                                        </tbody>
-                                     </table>
-                                  </li>
-                                  {{ end }}
-                                </ul>
-                            </div>
-                        </div>
-                        {{ end }}
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+    
+        {{ if (filter . "pending").Namespaces }}
+            {{template "section" (filter . "pending")}}
+        {{ end }}
+        
+        {{ if (filter . "failure").Namespaces }}
+            {{template "section" (filter . "failure")}}
+        {{ end }}
+
+        {{ if (filter . "warning").Namespaces }}
+            {{template "section" (filter . "warning")}}
+        {{ end }}
+
+
+        {{ if (filter . "success").Namespaces }}
+            {{template "section" (filter . "success")}}
+        {{ end }}
+
     {{ else }}
-    <h3 class="text-center">Waiting for information to be collected...</h3>
-    <h4 class="text-center">Refresh for updates and check the status and logs for the kube-applier container to make sure it is running properly.</h4>
+        <h3 class="text-center">Waiting for information to be collected...</h3>
+        <h4 class="text-center">Refresh for updates and check the status and logs for the kube-applier container to make sure it is running properly.</h4>
     {{ end }}
 </body>
 </html>
+{{ end }}
+
+<!-- Outcome Section -->
+{{define "section"}}
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default {{if eq $.Outcome "success"}}panel-success{{else if eq $.Outcome "failure"}}panel-danger{{end}}'>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#{{$.Outcome}}">
+                            {{if eq $.Outcome "pending"}}
+                                Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "failure"}}
+                                Failed Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "success"}}
+                                Applied Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{end}}
+                        </a>
+                    </h4>
+                </div>
+                <div id="{{$.Outcome}}" class="panel-group collapse in">
+                    {{ range $wb :=  .Namespaces }}
+                        {{template "namespace" $wb}}
+                    {{ end }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{{ end }}
+
+<!-- Namespace Info -->
+{{define "namespace"}}
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#{{.Waybill.Namespace}}">{{ .Waybill.Namespace }} {{ status .Waybill }}</a>
+      </div>
+  </div>
+  {{if .Waybill.Status.LastRun }}
+  <div id="{{.Waybill.Namespace}}" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>{{ .Waybill.Status.LastRun.Type }}<br/>
+                      
+                      {{ if .Waybill.Status.LastRun.Commit }}
+                      <strong>Commit: </strong>{{ if commitLink .DiffURLFormat .Waybill.Status.LastRun.Commit }}<a href="{{ commitLink .DiffURLFormat .Waybill.Status.LastRun.Commit }}">{{ .Waybill.Status.LastRun.Commit }}</a>{{ else }}{{ .Waybill.Status.LastRun.Commit }}{{ end }}<br/>
+                      {{ end }}
+                      
+                      <strong>Started: </strong>{{ formattedTime .Waybill.Status.LastRun.Started }} (took {{ latency .Waybill.Status.LastRun.Started .Waybill.Status.LastRun.Finished }})<br/>
+                      
+                      {{ if .Waybill.Status.LastRun.ErrorMessage}}
+                      <strong>Error Message: </strong>{{ .Waybill.Status.LastRun.ErrorMessage }}
+                      {{ end }}
+                  </div>
+                  <div class="col-md-2"><button data-namespace="{{ .Waybill.Namespace }}" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          {{ if .Waybill.Status.LastRun.Command }}
+          <li class="list-group-item">
+              <pre class="file-output">{{ printf "$ %s\n" .Waybill.Status.LastRun.Command }}{{ .Waybill.Status.LastRun.Output }}</pre>
+          </li>
+          {{ end }}
+          {{ if .Events }}
+          <li class="list-group-item">
+            <table class="table">
+              <thead>
+                  <tr>
+                  <th scope="col">LAST SEEN</th>
+                  <th scope="col">TYPE</th>
+                  <th scope="col">REASON</th>
+                  <th scope="col">MESSAGE</th>
+                 </tr>
+              </thead>
+              <tbody>
+              {{ range $i, $e := .Events }}
+                {{ if eq $e.Namespace $.Waybill.Namespace }}
+                    <tr>
+                    <td>{{ $e.LastTimestamp }}</th>
+                    <td>{{ $e.Type }}</td>
+                    <td>{{ $e.Reason }}</td>
+                    <td>{{ $e.Message }}</td>
+                </tr>
+                {{ end }}
+              {{ end }}
+              </tbody>
+           </table>
+        </li>
+        {{ end }}
+      </ul>
+  </div>
+  {{ end }}
+</div>
+{{ end }}

--- a/templates/status.html
+++ b/templates/status.html
@@ -30,7 +30,6 @@
             {{template "section" (filter . "warning")}}
         {{ end }}
 
-
         {{ if (filter . "success").Namespaces }}
             {{template "section" (filter . "success")}}
         {{ end }}
@@ -49,7 +48,7 @@
     <div class="col-md-2"></div>
     <div class="col-md-8">
         <div class="panel-group">
-            <div class='panel panel-default {{if eq $.Outcome "success"}}panel-success{{else if eq $.Outcome "failure"}}panel-danger{{end}}'>
+            <div class='panel panel-default {{if eq $.Outcome "success"}}panel-success{{else if eq $.Outcome "failure"}}panel-danger{{else if eq $.Outcome "warning"}}panel-warning{{end}}'>
                 <div class="panel-heading">
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#{{$.Outcome}}">
@@ -57,6 +56,8 @@
                                 Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.Outcome "failure"}}
                                 Failed Namespaces: {{ len .Namespaces }} / {{ .Total }}
+                            {{else if eq $.Outcome "warning"}}
+                                Applied Namespaces (with warning): {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.Outcome "success"}}
                                 Applied Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{end}}

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -28,7 +28,7 @@
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#pending">
                             
-                                Pending Namespaces: 2 / 7
+                                Pending Namespaces: 1 / 8
                             
                         </a>
                     </h4>
@@ -46,12 +46,128 @@
 </div>
 
                     
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
+
+        
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default '>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#auto-apply-disabled">
+                            
+                                Auto Apply Disabled Namespaces: 1 / 8
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="auto-apply-disabled" class="panel-group collapse in">
+                    
                         
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#bar">bar </a>
+          <a data-toggle="collapse" href="#bar">bar (auto-apply disabled)</a>
       </div>
+  </div>
+  
+</div>
+
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
+
+        
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default '>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#dry-run">
+                            
+                                Dry Run Only Namespaces: 1 / 8
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="dry-run" class="panel-group collapse in">
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#biz">biz (dry-run)</a>
+      </div>
+  </div>
+  
+  <div id="biz" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                      <strong>Error Message: </strong>exit status 1
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="biz" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <div class="file-output">
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_biz_main_repo_2305192794/dev/biz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n biz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+</div>
+                  
+                  <div>namespace/biz unchanged (server dry run)</div>
+                  
+                  <div>serviceaccount/fluentd unchanged (server dry run)</div>
+                  
+                  <div>serviceaccount/forwarder unchanged (server dry run)</div>
+                  
+                  <div>serviceaccount/kube-applier-delegate unchanged (server dry run)</div>
+                  
+                  <div>serviceaccount/loki unchanged (server dry run)</div>
+                  
+                  <div class="text-primary">rolebinding.rbac.authorization.k8s.io/admin configured (server dry run)</div>
+                  
+                  <div>rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged (server dry run)</div>
+                  
+                  <div class="text-warning">Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob</div>
+                  
+                  <div>secret/kube-applier-delegate-token unchanged (server dry run)</div>
+                  
+                  <div></div>
+                  
+               </div>
+          </li>
+          
+          
+      </ul>
   </div>
   
 </div>
@@ -76,7 +192,7 @@
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#failure">
                             
-                                Failed Namespaces: 2 / 7
+                                Failed Namespaces: 2 / 8
                             
                         </a>
                     </h4>
@@ -247,7 +363,7 @@
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#warning">
                             
-                                Applied Namespaces (with warning): 1 / 7
+                                Applied Namespaces (with warning): 1 / 8
                             
                         </a>
                     </h4>
@@ -283,7 +399,7 @@
           
           <li class="list-group-item">
               <div class="file-output">
-                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_fuz_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n fuz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
 </div>
                   
                   <div>namespace/fuz unchanged</div>
@@ -351,7 +467,7 @@
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#success">
                             
-                                Applied Namespaces: 2 / 7
+                                Applied Namespaces: 2 / 8
                             
                         </a>
                     </h4>
@@ -387,7 +503,7 @@
           
           <li class="list-group-item">
               <div class="file-output">
-                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_buz_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n buz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
 </div>
                   
                   <div>namespace/buz unchanged</div>
@@ -457,7 +573,7 @@
           
           <li class="list-group-item">
               <div class="file-output">
-                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_eng_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n eng --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
 </div>
                   
                   <div>namespace/eng unchanged</div>

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -1,0 +1,395 @@
+
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>kube-applier</title>
+    <script src="/static/bootstrap/js/jquery.min.js"></script>
+    <script src="/static/js/main.js"></script>
+    <link rel="stylesheet" href="/static/stylesheets/main.css">
+    <link rel="stylesheet" href="/static/bootstrap/css/bootstrap.min.css">
+    <script src="/static/bootstrap/js/bootstrap.min.js"></script>
+</head>
+<body>
+    <h1 class="text-center">kube-applier</h1>
+    
+        <div class="row">
+            <div class="col-md-4"></div>
+            <div id="force-alert-container" class="col-md-4"></div>
+        </div>
+    
+        
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default '>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#pending">
+                            
+                                Pending Namespaces: 2 / 7
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="pending" class="panel-group collapse in">
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#foo">foo </a>
+      </div>
+  </div>
+  
+</div>
+
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#bar">bar </a>
+      </div>
+  </div>
+  
+</div>
+
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
+        
+        
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default panel-danger'>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#failure">
+                            
+                                Failed Namespaces: 2 / 7
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="failure" class="panel-group collapse in">
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#zot">zot </a>
+      </div>
+  </div>
+  
+  <div id="zot" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Git polling run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                      <strong>Error Message: </strong>exit status 1
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="zot" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          
+          <li class="list-group-item">
+            <table class="table">
+              <thead>
+                  <tr>
+                  <th scope="col">LAST SEEN</th>
+                  <th scope="col">TYPE</th>
+                  <th scope="col">REASON</th>
+                  <th scope="col">MESSAGE</th>
+                 </tr>
+              </thead>
+              <tbody>
+              
+                
+                    <tr>
+                    <td>2022-04-26 13:40:05 &#43;0000 UTC</th>
+                    <td>Warning</td>
+                    <td>WaybillRunRequestFailed</td>
+                    <td>failed fetching delegate token: secrets &#34;kube-applier-delegate-token&#34; not found</td>
+                </tr>
+                
+              
+              </tbody>
+           </table>
+        </li>
+        
+      </ul>
+  </div>
+  
+</div>
+
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#zoo">zoo </a>
+      </div>
+  </div>
+  
+  <div id="zoo" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                      <strong>Error Message: </strong>exit status 1
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="zoo" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/zoo | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+namespace/zoo unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;
+unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;
+</pre>
+          </li>
+          
+          
+      </ul>
+  </div>
+  
+</div>
+
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
+
+        
+
+
+        
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default panel-success'>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#success">
+                            
+                                Applied Namespaces: 3 / 7
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="success" class="panel-group collapse in">
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#buz">buz </a>
+      </div>
+  </div>
+  
+  <div id="buz" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="buz" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+namespace/buz unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+</pre>
+          </li>
+          
+          
+      </ul>
+  </div>
+  
+</div>
+
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#eng">eng </a>
+      </div>
+  </div>
+  
+  <div id="eng" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="eng" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+namespace/eng unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+</pre>
+          </li>
+          
+          
+      </ul>
+  </div>
+  
+</div>
+
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#fuz">fuz </a>
+      </div>
+  </div>
+  
+  <div id="fuz" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="fuz" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+namespace/fuz unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler
+Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob
+Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use policy/v1 PodDisruptionBudget
+Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use discovery.k8s.io/v1 EndpointSlice
+</pre>
+          </li>
+          
+          
+      </ul>
+  </div>
+  
+</div>
+
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
+
+    
+</body>
+</html>

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -218,7 +218,7 @@
                   
                   <div></div>
                   
-                </div>
+               </div>
           </li>
           
           
@@ -322,7 +322,7 @@
                   
                   <div></div>
                   
-                </div>
+               </div>
           </li>
           
           
@@ -418,7 +418,7 @@
                   
                   <div></div>
                   
-                </div>
+               </div>
           </li>
           
           
@@ -472,7 +472,7 @@
                   
                   <div></div>
                   
-                </div>
+               </div>
           </li>
           
           

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -174,23 +174,51 @@
           </li>
           
           <li class="list-group-item">
-              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/zoo | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
-namespace/zoo unchanged
-serviceaccount/kube-applier-delegate unchanged
-rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
-configmap/postgres-init unchanged
-configmap/postgres-env unchanged
-service/postgres unchanged
-service/webapp unchanged
-limitrange/default configured
-persistentvolumeclaim/postgres unchanged
-deployment.apps/postgres unchanged
-deployment.apps/webapp configured
-waybill.kube-applier.io/main unchanged
-networkpolicy.networking.k8s.io/default unchanged
-unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;
-unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;
-</pre>
+              <div class="file-output">
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/zoo | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+</div>
+                  
+                  <div>namespace/zoo unchanged</div>
+                  
+                  <div>serviceaccount/kube-applier-delegate unchanged</div>
+                  
+                  <div>rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged</div>
+                  
+                  <div>configmap/postgres-init unchanged</div>
+                  
+                  <div>configmap/postgres-env unchanged</div>
+                  
+                  <div>service/postgres unchanged</div>
+                  
+                  <div>service/webapp unchanged</div>
+                  
+                  <div class="text-primary">limitrange/default configured</div>
+                  
+                  <div>persistentvolumeclaim/postgres unchanged</div>
+                  
+                  <div>deployment.apps/postgres unchanged</div>
+                  
+                  <div class="text-primary">deployment.apps/webapp configured</div>
+                  
+                  <div class="text-primary">deployment.apps/scheduler configured</div>
+                  
+                  <div class="text-warning">Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler</div>
+                  
+                  <div class="text-warning">Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob</div>
+                  
+                  <div>waybill.kube-applier.io/main unchanged</div>
+                  
+                  <div>networkpolicy.networking.k8s.io/default unchanged</div>
+                  
+                  <div class="text-danger">error: error validating &#34;/tmp/dev/secrets.yaml&#34;: </div>
+                  
+                  <div class="text-danger">unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;</div>
+                  
+                  <div class="text-danger">unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in version &#34;extensions/v1beta1&#34;</div>
+                  
+                  <div></div>
+                  
+                </div>
           </li>
           
           
@@ -254,25 +282,47 @@ unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in ve
           </li>
           
           <li class="list-group-item">
-              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
-namespace/fuz unchanged
-serviceaccount/kube-applier-delegate unchanged
-rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
-configmap/postgres-init unchanged
-configmap/postgres-env unchanged
-service/postgres unchanged
-service/webapp unchanged
-limitrange/default configured
-persistentvolumeclaim/postgres unchanged
-deployment.apps/postgres unchanged
-deployment.apps/webapp configured
-waybill.kube-applier.io/main unchanged
-networkpolicy.networking.k8s.io/default unchanged
-Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler
-Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob
-Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use policy/v1 PodDisruptionBudget
-Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use discovery.k8s.io/v1 EndpointSlice
-</pre>
+              <div class="file-output">
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+</div>
+                  
+                  <div>namespace/fuz unchanged</div>
+                  
+                  <div>serviceaccount/kube-applier-delegate unchanged</div>
+                  
+                  <div>rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged</div>
+                  
+                  <div>configmap/postgres-init unchanged</div>
+                  
+                  <div>configmap/postgres-env unchanged</div>
+                  
+                  <div>service/postgres unchanged</div>
+                  
+                  <div>service/webapp unchanged</div>
+                  
+                  <div class="text-primary">limitrange/default configured</div>
+                  
+                  <div>persistentvolumeclaim/postgres unchanged</div>
+                  
+                  <div>deployment.apps/postgres unchanged</div>
+                  
+                  <div class="text-primary">deployment.apps/webapp configured</div>
+                  
+                  <div>waybill.kube-applier.io/main unchanged</div>
+                  
+                  <div>networkpolicy.networking.k8s.io/default unchanged</div>
+                  
+                  <div class="text-warning">Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler</div>
+                  
+                  <div class="text-warning">Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob</div>
+                  
+                  <div class="text-warning">Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use policy/v1 PodDisruptionBudget</div>
+                  
+                  <div class="text-warning">Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use discovery.k8s.io/v1 EndpointSlice</div>
+                  
+                  <div></div>
+                  
+                </div>
           </li>
           
           
@@ -336,21 +386,39 @@ Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, una
           </li>
           
           <li class="list-group-item">
-              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
-namespace/buz unchanged
-serviceaccount/kube-applier-delegate unchanged
-rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
-configmap/postgres-init unchanged
-configmap/postgres-env unchanged
-service/postgres unchanged
-service/webapp unchanged
-limitrange/default configured
-persistentvolumeclaim/postgres unchanged
-deployment.apps/postgres unchanged
-deployment.apps/webapp configured
-waybill.kube-applier.io/main unchanged
-networkpolicy.networking.k8s.io/default unchanged
-</pre>
+              <div class="file-output">
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+</div>
+                  
+                  <div>namespace/buz unchanged</div>
+                  
+                  <div>serviceaccount/kube-applier-delegate unchanged</div>
+                  
+                  <div>rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged</div>
+                  
+                  <div>configmap/postgres-init unchanged</div>
+                  
+                  <div>configmap/postgres-env unchanged</div>
+                  
+                  <div>service/postgres unchanged</div>
+                  
+                  <div>service/webapp unchanged</div>
+                  
+                  <div class="text-primary">limitrange/default configured</div>
+                  
+                  <div>persistentvolumeclaim/postgres unchanged</div>
+                  
+                  <div>deployment.apps/postgres unchanged</div>
+                  
+                  <div class="text-primary">deployment.apps/webapp configured</div>
+                  
+                  <div>waybill.kube-applier.io/main unchanged</div>
+                  
+                  <div>networkpolicy.networking.k8s.io/default unchanged</div>
+                  
+                  <div></div>
+                  
+                </div>
           </li>
           
           
@@ -388,13 +456,23 @@ networkpolicy.networking.k8s.io/default unchanged
           </li>
           
           <li class="list-group-item">
-              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
-namespace/eng unchanged
-serviceaccount/kube-applier-delegate unchanged
-rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
-waybill.kube-applier.io/main unchanged
-networkpolicy.networking.k8s.io/default unchanged
-</pre>
+              <div class="file-output">
+                  <div>$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+</div>
+                  
+                  <div>namespace/eng unchanged</div>
+                  
+                  <div>serviceaccount/kube-applier-delegate unchanged</div>
+                  
+                  <div>rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged</div>
+                  
+                  <div>waybill.kube-applier.io/main unchanged</div>
+                  
+                  <div>networkpolicy.networking.k8s.io/default unchanged</div>
+                  
+                  <div></div>
+                  
+                </div>
           </li>
           
           

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html>
 <head>
@@ -210,7 +209,86 @@ unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in ve
         
 
         
+            
+<div class="row">
+    <div class="col-md-2"></div>
+    <div class="col-md-8">
+        <div class="panel-group">
+            <div class='panel panel-default panel-warning'>
+                <div class="panel-heading">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" href="#warning">
+                            
+                                Applied Namespaces (with warning): 1 / 7
+                            
+                        </a>
+                    </h4>
+                </div>
+                <div id="warning" class="panel-group collapse in">
+                    
+                        
+<div class="panel">
+  <div class="panel-heading">
+      <div class="panel-title">
+          <a data-toggle="collapse" href="#fuz">fuz </a>
+      </div>
+  </div>
+  
+  <div id="fuz" class="panel-collapse collapse">
+      <ul class="list-group">
+          <li class="list-group-item">
+              <div class="row">
+                  <div class="col-md-10">
+                      <strong>Type: </strong>Scheduled run<br/>
+                      
+                      
+                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
+                      
+                      
+                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
+                      
+                      
+                  </div>
+                  <div class="col-md-2"><button data-namespace="fuz" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
+              </div>
+          </li>
+          
+          <li class="list-group-item">
+              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
+namespace/fuz unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler
+Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob
+Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use policy/v1 PodDisruptionBudget
+Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use discovery.k8s.io/v1 EndpointSlice
+</pre>
+          </li>
+          
+          
+      </ul>
+  </div>
+  
+</div>
 
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+        
 
         
             
@@ -223,7 +301,7 @@ unable to recognize &#34;STDIN&#34;: no matches for kind &#34;Ingress&#34; in ve
                     <h4 class="panel-title">
                         <a data-toggle="collapse" href="#success">
                             
-                                Applied Namespaces: 3 / 7
+                                Applied Namespaces: 2 / 7
                             
                         </a>
                     </h4>
@@ -316,62 +394,6 @@ serviceaccount/kube-applier-delegate unchanged
 rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
 waybill.kube-applier.io/main unchanged
 networkpolicy.networking.k8s.io/default unchanged
-</pre>
-          </li>
-          
-          
-      </ul>
-  </div>
-  
-</div>
-
-                    
-                        
-<div class="panel">
-  <div class="panel-heading">
-      <div class="panel-title">
-          <a data-toggle="collapse" href="#fuz">fuz </a>
-      </div>
-  </div>
-  
-  <div id="fuz" class="panel-collapse collapse">
-      <ul class="list-group">
-          <li class="list-group-item">
-              <div class="row">
-                  <div class="col-md-10">
-                      <strong>Type: </strong>Scheduled run<br/>
-                      
-                      
-                      <strong>Commit: </strong><a href="https://github.com/org/repo/commit/22c815614b">22c815614b</a><br/>
-                      
-                      
-                      <strong>Started: </strong>2022-04-26 13:35:05 &#43;0000 UTC (took 60 sec)<br/>
-                      
-                      
-                  </div>
-                  <div class="col-md-2"><button data-namespace="fuz" class="force-button force-namespace-button btn btn-warning btn-s"><strong>Force apply run</strong></button></div>
-              </div>
-          </li>
-          
-          <li class="list-group-item">
-              <pre class="file-output">$ /usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=&lt;omitted&gt; -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged
-namespace/fuz unchanged
-serviceaccount/kube-applier-delegate unchanged
-rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
-configmap/postgres-init unchanged
-configmap/postgres-env unchanged
-service/postgres unchanged
-service/webapp unchanged
-limitrange/default configured
-persistentvolumeclaim/postgres unchanged
-deployment.apps/postgres unchanged
-deployment.apps/webapp configured
-waybill.kube-applier.io/main unchanged
-networkpolicy.networking.k8s.io/default unchanged
-Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22&#43;, unavailable in v1.25&#43;; use autoscaling/v2beta2 HorizontalPodAutoscaler
-Warning: batch/v1beta1 CronJob is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use batch/v1 CronJob
-Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use policy/v1 PodDisruptionBudget
-Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21&#43;, unavailable in v1.25&#43;; use discovery.k8s.io/v1 EndpointSlice
 </pre>
           </li>
           

--- a/webserver/result.go
+++ b/webserver/result.go
@@ -137,3 +137,25 @@ func appliedRecently(waybill kubeapplierv1alpha1.Waybill) bool {
 	return waybill.Status.LastRun != nil &&
 		time.Since(waybill.Status.LastRun.Started.Time) < time.Minute*15
 }
+
+func splitByNewline(output string) []string {
+	return strings.Split(output, "\n")
+}
+
+func getOutputClass(l string) string {
+	l = strings.TrimSpace(l)
+	if warningCheckReg.MatchString(l) {
+		return "text-warning"
+	}
+	if strings.HasSuffix(l, "configured") {
+		return "text-primary"
+	}
+	if strings.Contains(l, "unable to recognize") ||
+		strings.HasPrefix(l, "error:") {
+		return "text-danger"
+	}
+	if strings.Contains(l, "dry run") {
+		return "text-info"
+	}
+	return ""
+}

--- a/webserver/result.go
+++ b/webserver/result.go
@@ -12,52 +12,31 @@ import (
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 )
 
-// Result stores the current state of the waybills  The functions associated
-// with Result convert raw data into the desired formats
-// for insertion into the status page template.
-type Result struct {
+// namespace stores the current state of the waybill and events of a namespace.
+type Namespace struct {
+	Waybill       kubeapplierv1alpha1.Waybill
 	Events        []corev1.Event
-	Waybills      []kubeapplierv1alpha1.Waybill
 	DiffURLFormat string
 }
 
-// Successes returns all the Waybills that applied successfully.
-func (r *Result) Successes() []kubeapplierv1alpha1.Waybill {
-	var ret []kubeapplierv1alpha1.Waybill
-	for _, wb := range r.Waybills {
-		if wb.Status.LastRun != nil && wb.Status.LastRun.Success {
-			ret = append(ret, wb)
-		}
+// GetNamespaces will create Namespace object combining wayBill and its corresponding events
+func GetNamespaces(waybills []kubeapplierv1alpha1.Waybill, allEvents []corev1.Event, diffURL string) []Namespace {
+	var ns []Namespace
+	for _, wb := range waybills {
+		ns = append(ns, Namespace{
+			Waybill:       wb,
+			DiffURLFormat: diffURL,
+			Events:        waybillEvents(&wb, allEvents),
+		})
 	}
-	return ret
+
+	return ns
 }
 
-// Failures returns all the Waybills that failed applying.
-func (r *Result) Failures() []kubeapplierv1alpha1.Waybill {
-	var ret []kubeapplierv1alpha1.Waybill
-	for _, wb := range r.Waybills {
-		if wb.Status.LastRun != nil && !wb.Status.LastRun.Success {
-			ret = append(ret, wb)
-		}
-	}
-	return ret
-}
-
-// Pending returns all the Waybills that haven't ran yet
-func (r *Result) Pending() []kubeapplierv1alpha1.Waybill {
-	var ret []kubeapplierv1alpha1.Waybill
-	for _, wb := range r.Waybills {
-		if wb.Status.LastRun == nil {
-			ret = append(ret, wb)
-		}
-	}
-	return ret
-}
-
-// WaybillEvents returns all the events for the given Waybill
-func (r *Result) WaybillEvents(wb *kubeapplierv1alpha1.Waybill) []corev1.Event {
+// waybillEvents returns all the events for the given Waybill
+func waybillEvents(wb *kubeapplierv1alpha1.Waybill, allEvents []corev1.Event) []corev1.Event {
 	var events []corev1.Event
-	for _, e := range r.Events {
+	for _, e := range allEvents {
 		if e.InvolvedObject.Name == wb.Name && e.InvolvedObject.Namespace == wb.Namespace {
 			events = append(events, e)
 		}
@@ -66,33 +45,61 @@ func (r *Result) WaybillEvents(wb *kubeapplierv1alpha1.Waybill) []corev1.Event {
 	return events
 }
 
+// Filtered stores collections of Namespaces with same outsome
+type Filtered struct {
+	Outcome    string
+	Total      int
+	Namespaces []Namespace
+}
+
+func filter(Namespaces []Namespace, outcome string) Filtered {
+	filtered := Filtered{
+		Outcome: outcome,
+		Total:   len(Namespaces),
+	}
+	for _, ns := range Namespaces {
+		switch outcome {
+		case "pending":
+			if ns.Waybill.Status.LastRun == nil {
+				filtered.Namespaces = append(filtered.Namespaces, ns)
+			}
+		case "failure":
+			if ns.Waybill.Status.LastRun != nil && !ns.Waybill.Status.LastRun.Success {
+				filtered.Namespaces = append(filtered.Namespaces, ns)
+			}
+		case "success":
+			if ns.Waybill.Status.LastRun != nil && ns.Waybill.Status.LastRun.Success {
+				filtered.Namespaces = append(filtered.Namespaces, ns)
+			}
+		}
+	}
+	return filtered
+}
+
+// Helper functions used in templates
+
 // FormattedTime returns the Time in the format "YYYY-MM-DD hh:mm:ss -0000 GMT"
-func (r *Result) FormattedTime(t metav1.Time) string {
+func formattedTime(t metav1.Time) string {
 	return t.Time.Truncate(time.Second).String()
 }
 
 // Latency returns the latency between the two Times in seconds.
-func (r *Result) Latency(t1, t2 metav1.Time) string {
+func latency(t1, t2 metav1.Time) string {
 	return fmt.Sprintf("%.0f sec", t2.Time.Sub(t1.Time).Seconds())
 }
 
 // CommitLink returns a URL for the commit most recently applied or it returns
 // an empty string if it cannot construct the URL.
-func (r *Result) CommitLink(commit string) string {
-	if commit == "" || r.DiffURLFormat == "" || !strings.Contains(r.DiffURLFormat, "%s") {
+func commitLink(diffUrl, commit string) string {
+	if commit == "" || diffUrl == "" || !strings.Contains(diffUrl, "%s") {
 		return ""
 	}
-	return fmt.Sprintf(r.DiffURLFormat, commit)
-}
-
-// Finished returns true if the Result is from a finished apply run.
-func (r *Result) Finished() bool {
-	return len(r.Waybills) > 0
+	return fmt.Sprintf(diffUrl, commit)
 }
 
 // Status returns a human-readable string that describes the Waybill in terms
 // of its autoApply and dryRun attributes.
-func (r *Result) Status(wb *kubeapplierv1alpha1.Waybill) string {
+func status(wb kubeapplierv1alpha1.Waybill) string {
 	ret := []string{}
 	if !pointer.BoolPtrDerefOr(wb.Spec.AutoApply, true) {
 		ret = append(ret, "auto-apply disabled")
@@ -108,7 +115,7 @@ func (r *Result) Status(wb *kubeapplierv1alpha1.Waybill) string {
 
 // AppliedRecently checks whether the provided Waybill was applied in the last
 // 15 minutes.
-func (r *Result) AppliedRecently(waybill kubeapplierv1alpha1.Waybill) bool {
+func appliedRecently(waybill kubeapplierv1alpha1.Waybill) bool {
 	return waybill.Status.LastRun != nil &&
 		time.Since(waybill.Status.LastRun.Started.Time) < time.Minute*15
 }

--- a/webserver/result_test.go
+++ b/webserver/result_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	"github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,7 +151,7 @@ var events = []corev1.Event{
 func Test_GetNamespaces(t *testing.T) {
 	want := []Namespace{
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-success", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{Success: true}},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -160,7 +159,7 @@ func Test_GetNamespaces(t *testing.T) {
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-failure", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -177,7 +176,7 @@ func Test_GetNamespaces(t *testing.T) {
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-pending", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -194,7 +193,7 @@ func Test_GetNamespaces(t *testing.T) {
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-warning", Name: "main"},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
 				Status: kubeapplierv1alpha1.WaybillStatus{
@@ -208,7 +207,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 			},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		}, {
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-dryrun", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
@@ -216,7 +215,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-dryrun-warning", Name: "main"},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
 				Status: kubeapplierv1alpha1.WaybillStatus{
@@ -231,24 +230,24 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-dryrun-failure"},
-				Spec:       v1alpha1.WaybillSpec{DryRun: true},
-				Status:     v1alpha1.WaybillStatus{LastRun: &v1alpha1.WaybillStatusRun{}},
+				Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
+				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 			},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-disabled-AA"},
-				Spec:       v1alpha1.WaybillSpec{AutoApply: &varFalse},
+				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
 			},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-disabled-AA-warning"},
-				Spec:       v1alpha1.WaybillSpec{AutoApply: &varFalse},
+				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
 				Status: kubeapplierv1alpha1.WaybillStatus{
 					LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
 						Success: true,
@@ -261,10 +260,10 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
 		{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-disabled-AA-failure"},
-				Spec:       v1alpha1.WaybillSpec{AutoApply: &varFalse},
-				Status:     v1alpha1.WaybillStatus{LastRun: &v1alpha1.WaybillStatusRun{}},
+				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
+				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 			},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s",
 		},
@@ -289,7 +288,7 @@ func Test_filter(t *testing.T) {
 	}{
 		{"unknown", args{"unknown"}, Filtered{FilteredBy: "unknown", Total: 10}},
 		{"pending", args{"pending"}, Filtered{FilteredBy: "pending", Total: 10, Namespaces: []Namespace{{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-pending", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -297,7 +296,7 @@ func Test_filter(t *testing.T) {
 			DiffURLFormat: "https://github.com/org/repo/commit/%s"}}},
 		},
 		{"failure", args{"failure"}, Filtered{FilteredBy: "failure", Total: 10, Namespaces: []Namespace{{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-failure", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -305,7 +304,7 @@ func Test_filter(t *testing.T) {
 			DiffURLFormat: "https://github.com/org/repo/commit/%s"}}},
 		},
 		{"warning", args{"warning"}, Filtered{FilteredBy: "warning", Total: 10, Namespaces: []Namespace{{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-warning", Name: "main"},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
 				Status: kubeapplierv1alpha1.WaybillStatus{
@@ -320,7 +319,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 			DiffURLFormat: "https://github.com/org/repo/commit/%s"}}},
 		},
 		{"success", args{"success"}, Filtered{FilteredBy: "success", Total: 10, Namespaces: []Namespace{{
-			Waybill: v1alpha1.Waybill{
+			Waybill: kubeapplierv1alpha1.Waybill{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "test-success", Name: "main"},
 				Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{Success: true}},
 				Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varTrue},
@@ -329,7 +328,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 		},
 		{"dry-run", args{"dry-run"}, Filtered{FilteredBy: "dry-run", Total: 10, Namespaces: []Namespace{
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test-dryrun", Name: "main"},
 					Status:     kubeapplierv1alpha1.WaybillStatus{},
 					Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
@@ -337,7 +336,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test-dryrun-warning", Name: "main"},
 					Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
 					Status: kubeapplierv1alpha1.WaybillStatus{
@@ -352,10 +351,10 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-dryrun-failure"},
-					Spec:       v1alpha1.WaybillSpec{DryRun: true},
-					Status:     v1alpha1.WaybillStatus{LastRun: &v1alpha1.WaybillStatusRun{}},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{DryRun: true},
+					Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 				},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},
@@ -363,7 +362,7 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 		},
 		{"auto-apply-disabled", args{"auto-apply-disabled"}, Filtered{FilteredBy: "auto-apply-disabled", Total: 10, Namespaces: []Namespace{
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test-disabled-AA", Name: "main"},
 					Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
 					Status:     kubeapplierv1alpha1.WaybillStatus{},
@@ -371,9 +370,9 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-disabled-AA-warning"},
-					Spec:       v1alpha1.WaybillSpec{AutoApply: &varFalse},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
 					Status: kubeapplierv1alpha1.WaybillStatus{
 						LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
 							Success: true,
@@ -386,10 +385,10 @@ rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged`},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},
 			{
-				Waybill: v1alpha1.Waybill{
+				Waybill: kubeapplierv1alpha1.Waybill{
 					ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "test-disabled-AA-failure"},
-					Spec:       v1alpha1.WaybillSpec{AutoApply: &varFalse},
-					Status:     v1alpha1.WaybillStatus{LastRun: &v1alpha1.WaybillStatusRun{}},
+					Spec:       kubeapplierv1alpha1.WaybillSpec{AutoApply: &varFalse},
+					Status:     kubeapplierv1alpha1.WaybillStatus{LastRun: &kubeapplierv1alpha1.WaybillStatusRun{}},
 				},
 				DiffURLFormat: "https://github.com/org/repo/commit/%s",
 			},

--- a/webserver/template.go
+++ b/webserver/template.go
@@ -11,7 +11,16 @@ func createTemplate(templatePath string) (*template.Template, error) {
 	if _, err := os.Stat(templatePath); err != nil {
 		return nil, fmt.Errorf("Error opening template file: %v", err)
 	}
-	tmpl, err := template.ParseFiles(templatePath)
+	tmpl, err := template.New("index").
+		Funcs(template.FuncMap{
+			"filter":          filter,
+			"commitLink":      commitLink,
+			"formattedTime":   formattedTime,
+			"latency":         latency,
+			"appliedRecently": appliedRecently,
+			"status":          status,
+		}).
+		ParseFiles(templatePath)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing template: %v", err)
 	}

--- a/webserver/template.go
+++ b/webserver/template.go
@@ -19,6 +19,8 @@ func createTemplate(templatePath string) (*template.Template, error) {
 			"latency":         latency,
 			"appliedRecently": appliedRecently,
 			"status":          status,
+			"splitByNewline":  splitByNewline,
+			"getOutputClass":  getOutputClass,
 		}).
 		ParseFiles(templatePath)
 	if err != nil {

--- a/webserver/template_test.go
+++ b/webserver/template_test.go
@@ -1,0 +1,222 @@
+package webserver
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	diffURL      = "https://github.com/org/repo/commit/%s"
+	fixedTime    = time.Date(2022, time.April, 26, 13, 36, 05, 0, time.UTC)
+	emptyLineReg = regexp.MustCompile(`[\t\r\n]+`)
+
+	removeSpaceEmptyLine = cmp.Transformer("RemoveSpace", func(in string) string {
+		t := strings.ReplaceAll(in, "  ", "")
+		return emptyLineReg.ReplaceAllString(strings.TrimSpace(t), "\n")
+	})
+)
+
+func Test_ExecuteTemplate(t *testing.T) {
+	wbList := []kubeapplierv1alpha1.Waybill{
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "foo",
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "bar",
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "zot",
+			},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Commit:       "22c815614b",
+					ErrorMessage: `exit status 1`,
+					Started:      metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished:     metav1.Time{Time: fixedTime},
+					Type:         "Git polling run",
+				},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "zoo",
+			},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Command:      "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/zoo | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Commit:       "22c815614b",
+					ErrorMessage: `exit status 1`,
+					Started:      metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished:     metav1.Time{Time: fixedTime},
+					Type:         "Scheduled run",
+					Output: `namespace/zoo unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+unable to recognize "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
+unable to recognize "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
+`,
+				},
+			},
+		}, {
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "buz",
+			},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Commit:   "22c815614b",
+					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished: metav1.Time{Time: fixedTime},
+					Success:  true,
+					Type:     "Scheduled run",
+					Output: `namespace/buz unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+`,
+				},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "eng",
+			},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Commit:   "22c815614b",
+					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished: metav1.Time{Time: fixedTime},
+					Success:  true,
+					Type:     "Scheduled run",
+					Output: `namespace/eng unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+`,
+				},
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "fuz",
+			},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Commit:   "22c815614b",
+					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished: metav1.Time{Time: fixedTime},
+					Success:  true,
+					Type:     "Scheduled run",
+					Output: `namespace/fuz unchanged
+serviceaccount/kube-applier-delegate unchanged
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged
+configmap/postgres-init unchanged
+configmap/postgres-env unchanged
+service/postgres unchanged
+service/webapp unchanged
+limitrange/default configured
+persistentvolumeclaim/postgres unchanged
+deployment.apps/postgres unchanged
+deployment.apps/webapp configured
+waybill.kube-applier.io/main unchanged
+networkpolicy.networking.k8s.io/default unchanged
+Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler
+Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
+Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
+Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21+, unavailable in v1.25+; use discovery.k8s.io/v1 EndpointSlice
+`,
+				},
+			},
+		},
+	}
+
+	events := []corev1.Event{
+		{
+			TypeMeta:       metav1.TypeMeta{Kind: "Event", APIVersion: "v1"},
+			FirstTimestamp: metav1.Time{Time: fixedTime.Add(-4 * time.Minute)},
+			LastTimestamp:  metav1.Time{Time: fixedTime.Add(4 * time.Minute)},
+			Source:         corev1.EventSource{Component: "kube-applier"},
+			ObjectMeta:     metav1.ObjectMeta{Name: "main", Namespace: "zot"},
+			Type:           "Warning",
+			InvolvedObject: corev1.ObjectReference{Kind: "Waybill", Namespace: "zot", Name: "main"},
+			Message:        `failed fetching delegate token: secrets "kube-applier-delegate-token" not found`,
+			Reason:         "WaybillRunRequestFailed",
+		},
+	}
+
+	result := GetNamespaces(wbList, events, diffURL)
+
+	templt, err := createTemplate("../templates/status.html")
+	if err != nil {
+		t.Errorf("error parsing template: %v\n", err)
+		return
+	}
+
+	rendered := &bytes.Buffer{}
+	err = templt.ExecuteTemplate(rendered, "index", result)
+	if err != nil {
+		t.Errorf("error executing template: %v\n", err)
+		return
+	}
+
+	// read actual test html output file
+	want, err := os.ReadFile("../testdata/web/testStatusPage.html")
+	if err != nil {
+		t.Errorf("error reading test file:  %v\n", err)
+		return
+	}
+
+	if diff := cmp.Diff(string(want), rendered.String(), removeSpaceEmptyLine); diff != "" {
+		t.Errorf("ExecuteTemplate mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/webserver/template_test.go
+++ b/webserver/template_test.go
@@ -82,8 +82,12 @@ limitrange/default configured
 persistentvolumeclaim/postgres unchanged
 deployment.apps/postgres unchanged
 deployment.apps/webapp configured
+deployment.apps/scheduler configured
+Warning: autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler
+Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
 waybill.kube-applier.io/main unchanged
 networkpolicy.networking.k8s.io/default unchanged
+error: error validating "/tmp/dev/secrets.yaml": 
 unable to recognize "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
 unable to recognize "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
 `,

--- a/webserver/template_test.go
+++ b/webserver/template_test.go
@@ -33,12 +33,46 @@ func Test_ExecuteTemplate(t *testing.T) {
 				Name:      "main",
 				Namespace: "foo",
 			},
+			Spec: kubeapplierv1alpha1.WaybillSpec{
+				AutoApply: &varTrue,
+			},
 		},
 		{
 			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "main",
 				Namespace: "bar",
+			},
+			Spec: kubeapplierv1alpha1.WaybillSpec{
+				AutoApply: &varFalse,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "biz",
+			},
+			Spec: kubeapplierv1alpha1.WaybillSpec{DryRun: true},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Command:      "/usr/local/bin/kustomize build /tmp/run_biz_main_repo_2305192794/dev/biz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n biz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Commit:       "22c815614b",
+					ErrorMessage: `exit status 1`,
+					Started:      metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished:     metav1.Time{Time: fixedTime},
+					Type:         "Scheduled run",
+					Output: `namespace/biz unchanged (server dry run)
+serviceaccount/fluentd unchanged (server dry run)
+serviceaccount/forwarder unchanged (server dry run)
+serviceaccount/kube-applier-delegate unchanged (server dry run)
+serviceaccount/loki unchanged (server dry run)
+rolebinding.rbac.authorization.k8s.io/admin configured (server dry run)
+rolebinding.rbac.authorization.k8s.io/kube-applier-delegate unchanged (server dry run)
+Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
+secret/kube-applier-delegate-token unchanged (server dry run)
+`,
+				},
 			},
 		},
 		{
@@ -101,7 +135,7 @@ unable to recognize "STDIN": no matches for kind "Ingress" in version "extension
 			},
 			Status: kubeapplierv1alpha1.WaybillStatus{
 				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
-					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Command:  "/usr/local/bin/kustomize build /tmp/run_buz_main_repo_2305192794/dev/buz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n buz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
 					Commit:   "22c815614b",
 					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
 					Finished: metav1.Time{Time: fixedTime},
@@ -132,7 +166,7 @@ networkpolicy.networking.k8s.io/default unchanged
 			},
 			Status: kubeapplierv1alpha1.WaybillStatus{
 				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
-					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Command:  "/usr/local/bin/kustomize build /tmp/run_eng_main_repo_2305192794/dev/eng | /usr/local/bin/kubectl apply -f - --token=<omitted> -n eng --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
 					Commit:   "22c815614b",
 					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
 					Finished: metav1.Time{Time: fixedTime},
@@ -155,7 +189,7 @@ networkpolicy.networking.k8s.io/default unchanged
 			},
 			Status: kubeapplierv1alpha1.WaybillStatus{
 				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
-					Command:  "/usr/local/bin/kustomize build /tmp/run_zoo_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n zoo --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
+					Command:  "/usr/local/bin/kustomize build /tmp/run_fuz_main_repo_2305192794/dev/fuz | /usr/local/bin/kubectl apply -f - --token=<omitted> -n fuz --dry-run=none --prune --all --prune-whitelist=core/v1/ConfigMap serviceaccount/job-trigger unchanged serviceaccount/kube-applier-delegate unchanged",
 					Commit:   "22c815614b",
 					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
 					Finished: metav1.Time{Time: fixedTime},

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -86,13 +86,10 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Logger("webserver").Error("Unable to list Waybill events", "error", err, "time", s.Clock.Now().String())
 		return
 	}
-	result := &Result{
-		DiffURLFormat: s.DiffURLFormat,
-		Events:        events,
-		Waybills:      waybills,
-	}
+	result := GetNamespaces(waybills, events, s.DiffURLFormat)
+
 	rendered := &bytes.Buffer{}
-	if err := s.Template.Execute(rendered, result); err != nil {
+	if err := s.Template.ExecuteTemplate(rendered, "index", result); err != nil {
 		http.Error(w, "Error: Unable to render HTML template", http.StatusInternalServerError)
 		log.Logger("webserver").Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String(), "err", err)
 		return


### PR DESCRIPTION
This PR will create new section `warning` on status page. it will contain  all wayBill success with Warning in outcome of apply.

* refactored status page to use named nested template 
* added test for final status html based on test wayBills
* added warning section when successful apply got a warning in output. 

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/7142320/166516329-23a37a0b-9f5a-4ece-b490-ce6ed9934a5e.png">


<img width="953" alt="image" src="https://user-images.githubusercontent.com/7142320/165981834-c45ba142-df7d-4db9-9345-0dba595a74d8.png">

