### PR TITLE
Set STRONGBOX_HOME and gitconfig before running apply command

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,6 +168,7 @@ func main() {
 		PruneBlacklist: pruneBlacklistSlice,
 		Repository:     repo,
 		RepoPath:       *fRepoPath,
+		Strongbox:      &run.Strongboxer{},
 		WorkerCount:    *fWorkerCount,
 	}
 

--- a/run/runner.go
+++ b/run/runner.go
@@ -215,7 +215,8 @@ func (r *Runner) processRequest(request Request) error {
 	// in order to be available when we invoke git via running kustomize.
 	// That way we should also be able to decrypt files cloned from remote
 	// bases on kustomize build.
-	if err := r.Strongbox.SetupGitConfigForStrongbox(ctx, request.Waybill, tmpHomeDir); err != nil {
+	applyOptions.EnvironmentVariables = append(applyOptions.EnvironmentVariables, fmt.Sprintf("STRONGBOX_HOME=%s", tmpHomeDir))
+	if err := r.Strongbox.SetupGitConfigForStrongbox(ctx, request.Waybill, applyOptions.EnvironmentVariables); err != nil {
 		return err
 	}
 	r.apply(ctx, tmpRepoPath, delegateToken, request.Waybill, applyOptions)

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -115,6 +115,7 @@ var _ = Describe("Runner", func() {
 			PruneBlacklist: []string{"apps/v1/ControllerRevision"},
 			Repository:     repo,
 			RepoPath:       "testdata/manifests",
+			Strongbox:      &mockStrongboxer{},
 			WorkerCount:    1, // limit to one to prevent race issues
 		}
 

--- a/run/strongbox.go
+++ b/run/strongbox.go
@@ -13,7 +13,7 @@ import (
 
 // strongboxInterface holds functions to configure strongbox for waybill runs
 type StrongboxInterface interface {
-	SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error
+	SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, env []string) error
 	SetupStrongboxKeyring(ctx context.Context, kubeClient *client.Client, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error
 }
 
@@ -48,20 +48,14 @@ type Strongboxer struct {
 	strongboxBase
 }
 
-func (s *Strongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error {
+func (s *Strongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, env []string) error {
 	if waybill.Spec.StrongboxKeyringSecretRef == nil {
 		return nil
 	}
 
 	cmd := exec.CommandContext(ctx, "strongbox", "-git-config")
-	cmd.Dir = homeDir
-	// Set PATH so we can find strongbox bin and HOME and STRONGBOX_HOME to
-	// point to homeDir
-	cmd.Env = []string{
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
-		fmt.Sprintf("HOME=%s", homeDir),
-		fmt.Sprintf("STRONGBOX_HOME=%s", homeDir),
-	}
+	// Set PATH so we can find strongbox bin
+	cmd.Env = append(env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 	stderr, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error running strongbox err:%s %w ", stderr, err)
@@ -75,6 +69,6 @@ type mockStrongboxer struct {
 	strongboxBase
 }
 
-func (m *mockStrongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error {
+func (m *mockStrongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, env []string) error {
 	return nil
 }

--- a/run/strongbox.go
+++ b/run/strongbox.go
@@ -1,0 +1,80 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
+	"github.com/utilitywarehouse/kube-applier/client"
+)
+
+// strongboxInterface holds functions to configure strongbox for waybill runs
+type StrongboxInterface interface {
+	SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error
+	SetupStrongboxKeyring(ctx context.Context, kubeClient *client.Client, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error
+}
+
+type strongboxBase struct{}
+
+func (sb *strongboxBase) SetupStrongboxKeyring(ctx context.Context, kubeClient *client.Client, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error {
+	if waybill.Spec.StrongboxKeyringSecretRef == nil {
+		return nil
+	}
+	sbNamespace := waybill.Spec.StrongboxKeyringSecretRef.Namespace
+	if sbNamespace == "" {
+		sbNamespace = waybill.Namespace
+	}
+	secret, err := kubeClient.GetSecret(ctx, sbNamespace, waybill.Spec.StrongboxKeyringSecretRef.Name)
+	if err != nil {
+		return err
+	}
+	if err := checkSecretIsAllowed(waybill, secret); err != nil {
+		return err
+	}
+	strongboxData, ok := secret.Data[".strongbox_keyring"]
+	if !ok {
+		return fmt.Errorf(`secret "%s/%s" does not contain key '.strongbox_keyring'`, secret.Namespace, secret.Name)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, ".strongbox_keyring"), strongboxData, 0400); err != nil {
+		return err
+	}
+	return nil
+}
+
+type Strongboxer struct {
+	strongboxBase
+}
+
+func (s *Strongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error {
+	if waybill.Spec.StrongboxKeyringSecretRef == nil {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, "strongbox", "-git-config")
+	cmd.Dir = homeDir
+	// Set PATH so we can find strongbox bin and HOME and STRONGBOX_HOME to
+	// point to homeDir
+	cmd.Env = []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+		fmt.Sprintf("HOME=%s", homeDir),
+		fmt.Sprintf("STRONGBOX_HOME=%s", homeDir),
+	}
+	stderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error running strongbox err:%s %w ", stderr, err)
+	}
+
+	return nil
+}
+
+// Mock Strongboxer for testing
+type mockStrongboxer struct {
+	strongboxBase
+}
+
+func (m *mockStrongboxer) SetupGitConfigForStrongbox(ctx context.Context, waybill *kubeapplierv1alpha1.Waybill, homeDir string) error {
+	return nil
+}


### PR DESCRIPTION
Problem:
Repository clone happens using a global gitconfig for the current user (root)
that is already configured for strongbox in the Dockrfike we use to build
images. `kustomize` runs as part of Apply function when the controller has
created a temporary home dir to use in order to set ssh configs. If the
kustomize remote base contains strongbox encrypted files, then the temporary
home gitconfig is not configured to cover us so that we can decrypt successfully
on pull and remote base encrypted files remain encrypted.

This is trying to address the above by creating a temporary gitconfig under the
temp home per apply and sets STRONGBOX_HOME environment variable to point to
the temp home as well. More in particular:
- Creates an interface for strongbox and adds it to the Runner.
- Mocks the function that tries to exec strongbox in order to configure git for
  testing.
- Explicitly sets STRONGBOX_HOME before running apply command
