### PR TITLE
Use the git ssh key passed to KA as the default way of pulling via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ to prevent kube-applier from pruning it. However, since it is a secret itself
 and would need be encrypted as well in git, it must be created manually the
 first time (or after any changes to its contents).
 
+#### Private Kustomize Bases
+
+If not overridden via Waybill.Spec.gitSSHSecretRef configuration (see below),
+Kube-Applier will use the SSH key passed via `-git-ssh-key-path` as the default
+key flag to try fetching remote `kustomize` bases from private repositories.
+Since this relies on using SSH to fetch from upstreams, the bases should be
+defined with the `ssh://` scheme in `kustomization.yaml`.
+
 #### Custom SSH Keys
 
 You can specify custom SSH keys to be used for fetching remote `kustomize` bases

--- a/apis/kubeapplier/v1alpha1/waybill_types.go
+++ b/apis/kubeapplier/v1alpha1/waybill_types.go
@@ -26,10 +26,12 @@ type WaybillSpec struct {
 	// +kubebuilder:default=false
 	DryRun bool `json:"dryRun,omitempty"`
 
-	// GitSSHSecretRef references a Secret that contains an item named `key` and
+	// GitSSHSecretRef will override the default Git SSH key passed as a
+	// flag. It references a Secret that contains an item named `key` and
 	// optionally an item named `known_hosts`. If present, these are passed to
 	// the apply runtime and are used by `kustomize` when cloning remote bases.
-	// This allows the use of bases from private repositories.
+	// This allows the use of bases from private repositories that the default
+	// key will not have access to.
 	// +optional
 	GitSSHSecretRef *ObjectReference `json:"gitSSHSecretRef,omitempty"`
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 	fDryRun              = flag.Bool("dry-run", getBoolEnv("DRY_RUN", false), "Whether kube-applier operates in dry-run mode globally")
 	fGitPollWait         = flag.Duration("git-poll-wait", getDurationEnv("GIT_POLL_WAIT", time.Second*5), "How long kube-applier waits before checking for changes in the repository")
 	fGitKnownHostsPath   = flag.String("git-ssh-known-hosts-path", getStringEnv("GIT_KNOWN_HOSTS_PATH", ""), "Path to the known hosts file used for fetching the repository")
-	fGitSSHKeyPath       = flag.String("git-ssh-key-path", getStringEnv("GIT_SSH_KEY_PATH", ""), "Path to the SSH key file used for fetching the repository")
+	fGitSSHKeyPath       = flag.String("git-ssh-key-path", getStringEnv("GIT_SSH_KEY_PATH", ""), "Path to the SSH key file used for fetching the repository. This will also be used for any Kustomize bases fetched via ssh, unless overridden by Waybill.Spec.GitSSHSecretRef config")
 	fListenPort          = flag.Int("listen-port", getIntEnv("LISTEN_PORT", 8080), "Port that the http server is listening on")
 	fLogLevel            = flag.String("log-level", getStringEnv("LOG_LEVEL", "warn"), "Logging level: trace, debug, info, warn, error, off")
 	fOidcCallbackURL     = flag.String("oidc-callback-url", getStringEnv("OIDC_CALLBACK_URL", ""), "OIDC callback url should be the root URL where kube-applier is exposed")
@@ -161,15 +161,16 @@ func main() {
 	}
 
 	runner := &run.Runner{
-		Clock:          clock,
-		DryRun:         *fDryRun,
-		KubeClient:     kubeClient,
-		KubeCtlClient:  kubeCtlClient,
-		PruneBlacklist: pruneBlacklistSlice,
-		Repository:     repo,
-		RepoPath:       *fRepoPath,
-		Strongbox:      &run.Strongboxer{},
-		WorkerCount:    *fWorkerCount,
+		Clock:                clock,
+		DefaultGitSSHKeyPath: *fGitSSHKeyPath,
+		DryRun:               *fDryRun,
+		KubeClient:           kubeClient,
+		KubeCtlClient:        kubeCtlClient,
+		PruneBlacklist:       pruneBlacklistSlice,
+		Repository:           repo,
+		RepoPath:             *fRepoPath,
+		Strongbox:            &run.Strongboxer{},
+		WorkerCount:          *fWorkerCount,
 	}
 
 	runQueue := runner.Start()

--- a/manifests/base/cluster/kube-applier.io_waybills.yaml
+++ b/manifests/base/cluster/kube-applier.io_waybills.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: waybills.kube-applier.io
 spec:
@@ -80,11 +80,6 @@ spec:
                 description: AutoApply determines whether this Waybill will be automatically
                   applied by scheduled or polling runs.
                 type: boolean
-              autoTest:
-                default: true
-                description: AutoTest determines whether this Waybill will be automatically
-                  applied by scheduled or polling runs.
-                type: boolean
               delegateServiceAccountSecretRef:
                 default: kube-applier-delegate-token
                 description: DelegateServiceAccountSecretRef references a Secret of
@@ -98,11 +93,12 @@ spec:
                 description: DryRun enables the dry-run flag when applying this Waybill.
                 type: boolean
               gitSSHSecretRef:
-                description: GitSSHSecretRef references a Secret that contains an
-                  item named `key` and optionally an item named `known_hosts`. If
-                  present, these are passed to the apply runtime and are used by `kustomize`
-                  when cloning remote bases. This allows the use of bases from private
-                  repositories.
+                description: GitSSHSecretRef will override the default Git SSH key
+                  passed as a flag. It references a Secret that contains an item named
+                  `key` and optionally an item named `known_hosts`. If present, these
+                  are passed to the apply runtime and are used by `kustomize` when
+                  cloning remote bases. This allows the use of bases from private
+                  repositories that the default key will not have access to.
                 properties:
                   name:
                     description: Name of the resource being referred to.
@@ -225,9 +221,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/testdata/manifests/app-d-kustomize/00-namespace.yaml
+++ b/testdata/manifests/app-d-kustomize/00-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: app-d-kustomize

--- a/testdata/manifests/app-d-kustomize/kustomization.yaml
+++ b/testdata/manifests/app-d-kustomize/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - ssh://github.com/utilitywarehouse/kube-applier//testdata/bases/simple-deployment?ref=default-ssh-key
+resources:
+  - 00-namespace.yaml


### PR DESCRIPTION
Use the git ssh key passed as a flag as the default way to pull kustomize bases from private repositories, while still allowing this to be overwritten by Waybill GitSSHSecretRef field