### PR TITLE
Update go version to latest (1.24)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
 
 WORKDIR /src
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/utilitywarehouse/kube-applier
 
-go 1.22.0
-
-toolchain go1.22.5
+go 1.24.1
 
 require (
 	github.com/go-test/deep v1.0.5


### PR DESCRIPTION
Bump alpine image in Dockerfile and:
```
go get go@latest
go: updating go.mod requires go >= 1.24.1; switching to go1.24.1
go: upgraded go 1.22.0 => 1.24.1
go: removed toolchain go1.22.5
```
That should also fix the build failing dependencies