### PR TITLE
Fix git polling stuck on empty LastRun commit

### DIFF
--- a/run/runner.go
+++ b/run/runner.go
@@ -287,12 +287,23 @@ func (r *Runner) updateWaybillStatusRequestFailure(req Request, errorMessage str
 	wbId := fmt.Sprintf("%s/%s", req.Waybill.Namespace, req.Waybill.Name)
 	wb, err := r.KubeClient.GetWaybill(ctx, req.Waybill.Namespace, req.Waybill.Name)
 	if err != nil {
+		// GetWaybill returns a nil Waybill on error, so we cannot continue
+		// to build a status update below without dereferencing nil.
 		log.Logger("runner").Error("Cannot get waybill to capture request error", "waybill", wbId, "error", err)
+		return
+	}
+	// Preserve the previous LastRun.Commit so a pre-apply failure does
+	// not clobber a known-good commit hash with "". The empty commit
+	// would cause the scheduler's git polling loop to feed "" to
+	// git diff, which git rejects with "fatal: bad revision ''".
+	prevCommit := ""
+	if wb.Status.LastRun != nil {
+		prevCommit = wb.Status.LastRun.Commit
 	}
 	t := r.Clock.Now()
 	wb.Status.LastRun = &kubeapplierv1alpha1.WaybillStatusRun{
 		Command:      "",
-		Commit:       "",
+		Commit:       prevCommit,
 		Output:       "",
 		ErrorMessage: errorMessage,
 		Finished:     metav1.NewTime(t),

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -219,6 +219,16 @@ func (s *Scheduler) waybillsWithGitChanges() []*kubeapplierv1alpha1.Waybill {
 			continue
 		}
 		sinceHash := waybills[i].Status.LastRun.Commit
+		if sinceHash == "" {
+			// Empty Commit indicates a prior pre-apply failure corrupted
+			// the status. Enqueue a run to repair it rather than feeding
+			// "" to git diff. Best-effort: gated on HEAD moving (see the
+			// gitLastQueuedHash guard above), so autoApply Waybills also
+			// self-heal via the Scheduled run, but autoApply-disabled ones
+			// need a ForcedRun since Enqueue drops everything else.
+			result = append(result, waybills[i])
+			continue
+		}
 		path := waybills[i].Spec.RepositoryPath
 		if path == "" {
 			path = waybills[i].Namespace

--- a/run/scheduler_git_test.go
+++ b/run/scheduler_git_test.go
@@ -149,6 +149,27 @@ func TestWaybillsWithGitChanges(t *testing.T) {
 		assert.Equal(t, "scheduler-polling-app-a-kustomize", result[0].Namespace)
 	})
 
+	t.Run("returns Waybill with empty Commit in LastRun", func(t *testing.T) {
+		s := makeScheduler(map[string]*kubeapplierv1alpha1.Waybill{
+			"empty-commit": {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "empty-commit"},
+				Spec: kubeapplierv1alpha1.WaybillSpec{
+					RepositoryPath: "app-a",
+				},
+				Status: kubeapplierv1alpha1.WaybillStatus{
+					LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+						Commit:   "",
+						Started:  now,
+						Finished: now,
+					},
+				},
+			},
+		}, "")
+		result := s.waybillsWithGitChanges()
+		require.Len(t, result, 1)
+		assert.Equal(t, "empty-commit", result[0].Namespace)
+	})
+
 	t.Run("returns only changed Waybills from a mixed set", func(t *testing.T) {
 		s := makeScheduler(map[string]*kubeapplierv1alpha1.Waybill{
 			"no-last-run": {


### PR DESCRIPTION
Fixes kube-applier's git polling getting stuck when a transient
pre-apply failure corrupts Waybill.Status.LastRun.Commit to empty
string. The empty commit was fed to git diff, which git rejected
with "fatal: bad revision ''", skipping the waybill indefinitely
until pod restart.

- run/runner.go: preserve previous LastRun.Commit on pre-apply
  failure instead of clobbering with ""; add early return on
  GetWaybill error to fix a pre-existing nil-pointer dereference
- run/scheduler.go: guard against empty LastRun.Commit by
  enqueuing a PollingRun to repair the status
- run/scheduler_git_test.go: add test case for empty
  LastRun.Commit
