### PR TITLE
Simplify test setup and remove heavy integration gating

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,8 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
-      - name: Run full test suite
+      - name: Run test suite
         run: make test
-      - name: Run heavy integration suite
-        run: make test-heavy
 
   docker:
     needs: test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository. Keep it short and correct;
+update it when a convention changes.
+
+## What this is
+
+kube-applier (`github.com/utilitywarehouse/kube-applier`, Go 1.25) is a Kubernetes
+controller that applies declarative manifests from a git repo to the cluster it
+runs in. Entry point is `main.go`; the core packages are:
+
+- `run/` — scheduler, runner, and the apply loop (most logic lives here)
+- `git/` — repository polling and change detection
+- `client/` — Kubernetes client wrappers
+- `apis/` — the `Waybill` CRD types
+- `kubectl/`, `kustomizeutil/`, `webserver/`, `metrics/`, `sysutil/`, `log/`
+
+## Testing — use the Makefile, not `go test` directly
+
+The `run` package tests use envtest, which needs kube control-plane binaries
+(etcd/kube-apiserver). Running `go test ./run/...` directly fails with
+`fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory` because
+`KUBEBUILDER_ASSETS` is unset.
+
+`make test` handles this: it installs `setup-envtest`, downloads the binaries
+into `./kubebuilder-bindir` (gitignored), exports `KUBEBUILDER_ASSETS`, and runs
+the whole suite with `-race` and coverage. This is the single target for
+everything; CI runs it too.
+
+Notes:
+- A few specs need the `strongbox` binary on PATH (it decrypts fixtures via a git
+  filter). They self-skip when it's missing, so you don't need strongbox
+  installed to run the suite.
+- First run needs network access to fetch the envtest assets; later runs reuse
+  the cache in `kubebuilder-bindir`.
+- envtest is pinned to `KUBEBUILDER_VERSION` (currently `1.30.x`) in the Makefile,
+  independent of the runtime kubectl version.
+- Pure unit tests that don't touch envtest (e.g. `TestWaybillsWithGitChanges`)
+  can be run with plain `go test -run ...`, but when in doubt use `make test`.
+
+## Codegen
+
+CRD/RBAC manifests and deepcopy code are generated — after changing `apis/`:
+
+- `make manifests` — regenerate CRDs (needs `controller-gen`, auto-installed)
+- `make generate` — regenerate deepcopy code
+
+## Build
+
+- `go build ./...` for a quick compile check
+- `make build` builds the Docker image
+
+## Conventions
+
+- Commit messages: plain imperative sentences, no conventional-commit prefixes
+  (`feat:`/`fix:`/etc.) — matches this repo's history.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: manifests generate controller-gen-install test test-heavy test-heavy-strongbox build run release
+.PHONY: manifests generate controller-gen-install test build run release
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests: controller-gen-install
@@ -32,23 +32,14 @@ controller-gen-install:
 
 KUBEBUILDER_BINDIR=$${PWD}/kubebuilder-bindir
 KUBEBUILDER_VERSION="1.30.x"
+# Single test target: runs the whole suite under the race detector. The
+# strongbox specs self-skip when the `strongbox` binary is not on PATH (see
+# skipUnlessStrongbox in run/runner_test.go), so this passes with or without it.
 test:
 	command -v setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 	mkdir -p $(KUBEBUILDER_BINDIR)
 	ASSETS=$$(realpath $$(setup-envtest --bin-dir $(KUBEBUILDER_BINDIR) use -p path $(KUBEBUILDER_VERSION))); \
 	KUBEBUILDER_ASSETS="$$ASSETS" CGO_ENABLED=1 go test -v -race -count=1 -cover ./...
-
-test-heavy:
-	command -v setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	mkdir -p $(KUBEBUILDER_BINDIR)
-	ASSETS=$$(realpath $$(setup-envtest --bin-dir $(KUBEBUILDER_BINDIR) use -p path $(KUBEBUILDER_VERSION))); \
-	RUN_HEAVY_INTEGRATION=1 KUBEBUILDER_ASSETS="$$ASSETS" CGO_ENABLED=1 go test -v -count=1 ./run/...
-
-test-heavy-strongbox:
-	command -v setup-envtest || go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	mkdir -p $(KUBEBUILDER_BINDIR)
-	ASSETS=$$(realpath $$(setup-envtest --bin-dir $(KUBEBUILDER_BINDIR) use -p path $(KUBEBUILDER_VERSION))); \
-	RUN_HEAVY_INTEGRATION=1 RUN_HEAVY_STRONGBOX=1 KUBEBUILDER_ASSETS="$$ASSETS" CGO_ENABLED=1 go test -v -count=1 ./run/...
 
 build:
 	docker build -t kube-applier .

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -52,26 +53,13 @@ V0dTRjltUDh1L21mYklCTnBsMjhYMnFnQTQ5bkw3UFJHRwp2dStZZTVYQmxhaEVDbHZ5ZURFb0FB
 QUFER0ZzYTJGeVFHdDFhbWx5WVFFPQotLS0tLUVORCBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0K`)
 )
 
-const (
-	runHeavyIntegrationEnvVar = "RUN_HEAVY_INTEGRATION"
-	runHeavyStrongboxEnvVar   = "RUN_HEAVY_STRONGBOX"
-)
-
-func skipUnlessHeavyIntegration() {
-	if os.Getenv(runHeavyIntegrationEnvVar) == "1" {
-		return
+// skipUnlessStrongbox skips specs that rely on the strongbox binary (used as a
+// git filter to decrypt the encrypted fixtures) when it is not installed on
+// PATH. Everything else in this suite always runs.
+func skipUnlessStrongbox() {
+	if _, err := exec.LookPath("strongbox"); err != nil {
+		Skip("strongbox binary not found on PATH; skipping strongbox spec")
 	}
-	Skip(fmt.Sprintf("set %s=1 to run this heavy integration spec", runHeavyIntegrationEnvVar))
-}
-
-func skipUnlessHeavyStrongbox() {
-	if os.Getenv(runHeavyIntegrationEnvVar) != "1" {
-		Skip(fmt.Sprintf("set %s=1 to run this heavy integration spec", runHeavyIntegrationEnvVar))
-	}
-	if os.Getenv(runHeavyStrongboxEnvVar) == "1" {
-		return
-	}
-	Skip(fmt.Sprintf("set %s=1 to run strongbox heavy integration specs", runHeavyStrongboxEnvVar))
 }
 
 func TestApplyOptions_pruneWhitelist(t *testing.T) {
@@ -385,8 +373,6 @@ Some error output has been omitted because it may contain sensitive data
 
 	Context("When operating on a Waybill that defines a git ssh Secret", func() {
 		It("Should be able to use it to pull remote kustomize bases", func() {
-			skipUnlessHeavyIntegration()
-
 			// 1. app-b-kustomize-nokey
 			// 2. app-b-kustomize-notfound
 			// 3. app-b-kustomize-noaccess
@@ -635,8 +621,6 @@ deployment.apps/test-deployment created
 
 	Context("When operating on a Waybill that uses kustomize with no git secret it should fall back to KA ssh key", func() {
 		It("Should be able to build and apply", func() {
-			skipUnlessHeavyIntegration()
-
 			sshKey, err := os.CreateTemp("", "testGitSSHKey")
 			if err != nil {
 				panic(err)
@@ -699,7 +683,7 @@ deployment.apps/test-deployment created
 
 	Context("When operating on a Waybill that defines a strongbox keyring", func() {
 		It("Should be able to apply encrypted files, given a strongbox keyring secret", func() {
-			skipUnlessHeavyStrongbox()
+			skipUnlessStrongbox()
 
 			wbList := []*kubeapplierv1alpha1.Waybill{
 				{
@@ -788,7 +772,7 @@ deployment.apps/test-deployment created
 
 	Context("When operating on a Waybill that defines a Strongbox identity", func() {
 		It("Should be able to apply encrypted files, given a Strongbox identity Secret", func() {
-			skipUnlessHeavyStrongbox()
+			skipUnlessStrongbox()
 
 			wbList := []*kubeapplierv1alpha1.Waybill{
 				{


### PR DESCRIPTION
- Removed the "Run heavy integration suite" step from CI workflow; CI now runs only make test.
- Removed test-heavy and test-heavy-strongbox targets from Makefile; make test is the single test target for everything.
- Added a comment in Makefile explaining that strongbox specs self-skip when the binary is absent.
- Replaced RUN_HEAVY_INTEGRATION / RUN_HEAVY_STRONGBOX environment variable gating in runner_test.go with a single skipUnlessStrongbox helper.
- SSH key and kustomize specs that were previously behind env var guards now run unconditionally.
- Added AGENTS.md with guidance for coding agents working in this repository.