### PR TITLE
Surface Secret names on failed Secret applies

### DIFF
--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -319,12 +319,13 @@ func secretsErrMessage(secrets []byte) string {
 	var names []string
 	for _, obj := range objs {
 		name := obj.GetName()
+		if name == "" {
+			continue
+		}
 		if ns := obj.GetNamespace(); ns != "" {
 			name = ns + "/" + name
 		}
-		if name != "" {
-			names = append(names, name)
-		}
+		names = append(names, name)
 	}
 	if len(names) == 0 {
 		return omitErrOutputMessage

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -220,14 +221,14 @@ func (c *Client) applyKustomize(ctx context.Context, path string, options ApplyO
 		secretsOptions := options
 		secretsOptions.PruneWhitelist = secretsPruneWhitelist
 
-		_, out, err := c.apply(ctx, "-", secrets, secretsOptions)
+		_, secretsOut, err := c.apply(ctx, "-", secrets, secretsOptions)
 		if err != nil {
-			// Don't append the actual output, as the error output
-			// from kubectl can leak the content of secrets
-			kubectlOut = kubectlOut + omitErrOutputMessage
+			// Don't include kubectl's output — it can echo back Secret values.
+			// Surface the names of the affected Secrets instead.
+			kubectlOut = kubectlOut + secretsErrMessage(secrets)
 			return cmdStr, kubectlOut, err
 		}
-		kubectlOut = kubectlOut + out
+		kubectlOut = kubectlOut + secretsOut
 	}
 
 	return cmdStr, kubectlOut, nil
@@ -282,6 +283,32 @@ func filterErrOutput(out string) string {
 	}
 
 	return out
+}
+
+// secretsErrMessage returns a message identifying the Secret(s) whose apply
+// failed. kubectl's raw error output is not included because it can echo back
+// Secret values. If the manifest cannot be parsed we fall back to the generic
+// omission message.
+func secretsErrMessage(secrets []byte) string {
+	objs, err := splitYAML(secrets)
+	if err != nil {
+		return omitErrOutputMessage
+	}
+	var names []string
+	for _, obj := range objs {
+		name := obj.GetName()
+		if ns := obj.GetNamespace(); ns != "" {
+			name = ns + "/" + name
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	if len(names) == 0 {
+		return omitErrOutputMessage
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("Error applying Secret(s) [%s]; kubectl output has been omitted as it may contain sensitive data.\n", strings.Join(names, ", "))
 }
 
 // splitSecrets will take a yaml file and separate the resources into Secrets

--- a/kubectl/client.go
+++ b/kubectl/client.go
@@ -223,8 +223,10 @@ func (c *Client) applyKustomize(ctx context.Context, path string, options ApplyO
 
 		_, secretsOut, err := c.apply(ctx, "-", secrets, secretsOptions)
 		if err != nil {
-			// Don't include kubectl's output — it can echo back Secret values.
-			// Surface the names of the affected Secrets instead.
+			// Don't include kubectl's output — on a failed apply kubectl
+			// echoes a "bigger context" window of the raw manifest JSON,
+			// which can include Secret data field values. Surface only the
+			// names of the affected Secrets instead.
 			kubectlOut = kubectlOut + secretsErrMessage(secrets)
 			return cmdStr, kubectlOut, err
 		}
@@ -289,6 +291,26 @@ func filterErrOutput(out string) string {
 // failed. kubectl's raw error output is not included because it can echo back
 // Secret values. If the manifest cannot be parsed we fall back to the generic
 // omission message.
+//
+// secrets is the multi-document YAML produced by splitSecrets — the subset of
+// the kustomize build output that contains only Secret resources, separated by
+// "---", for example:
+//
+//	apiVersion: v1
+//	kind: Secret
+//	metadata:
+//	  name: db-creds
+//	  namespace: example-ns
+//	data:
+//	  password: c2VjcmV0
+//	---
+//	apiVersion: v1
+//	kind: Secret
+//	metadata:
+//	  name: api-token
+//	  namespace: example-ns
+//	stringData:
+//	  token: my-plaintext-token-value
 func secretsErrMessage(secrets []byte) string {
 	objs, err := splitYAML(secrets)
 	if err != nil {

--- a/kubectl/client_test.go
+++ b/kubectl/client_test.go
@@ -143,6 +143,17 @@ data:
 			want: "Error applying Secret(s) [bare-secret]; kubectl output has been omitted as it may contain sensitive data.\n",
 		},
 		{
+			name: "falls back to generic message when Secret YAML has no metadata.name",
+			secrets: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  namespace: example-ns
+data:
+  key: dmFsdWU=
+`),
+			want: omitErrOutputMessage,
+		},
+		{
 			name:    "falls back to generic message when secrets cannot be parsed",
 			secrets: []byte("this: is: not: valid: yaml:\n  - {["),
 			want:    omitErrOutputMessage,

--- a/kubectl/client_test.go
+++ b/kubectl/client_test.go
@@ -105,6 +105,65 @@ The request is invalid: patch: Invalid value: "map[data:map[invalid:map[]] metad
 	}
 }
 
+func TestSecretsErrMessage(t *testing.T) {
+	testCases := []struct {
+		name    string
+		secrets []byte
+		want    string
+	}{
+		{
+			name: "includes namespace-qualified names of all Secrets",
+			secrets: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: db-creds
+  namespace: example-ns
+data:
+  password: c2VjcmV0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: api-token
+  namespace: example-ns
+stringData:
+  token: my-plaintext-token-value
+`),
+			want: "Error applying Secret(s) [example-ns/api-token, example-ns/db-creds]; kubectl output has been omitted as it may contain sensitive data.\n",
+		},
+		{
+			name: "works for a Secret with no namespace",
+			secrets: []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: bare-secret
+data:
+  key: dmFsdWU=
+`),
+			want: "Error applying Secret(s) [bare-secret]; kubectl output has been omitted as it may contain sensitive data.\n",
+		},
+		{
+			name:    "falls back to generic message when secrets cannot be parsed",
+			secrets: []byte("this: is: not: valid: yaml:\n  - {["),
+			want:    omitErrOutputMessage,
+		},
+		{
+			name:    "falls back to generic message for empty input",
+			secrets: []byte{},
+			want:    omitErrOutputMessage,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := secretsErrMessage(tc.secrets)
+			if diff := deep.Equal(got, tc.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
 func TestApplyOptionsArgs(t *testing.T) {
 	testCases := []struct {
 		options ApplyOptions

--- a/run/runner_test.go
+++ b/run/runner_test.go
@@ -346,7 +346,7 @@ deployment.apps/test-deployment created (server dry run)
 					Finished:     metav1.Time{},
 					Output: `namespace/app-a-kustomize configured
 deployment.apps/test-deployment created
-Some error output has been omitted because it may contain sensitive data
+Error applying Secret(s) [-invalid]; kubectl output has been omitted as it may contain sensitive data.
 `,
 					Started: metav1.Time{},
 					Success: false,


### PR DESCRIPTION
When the secrets apply pass fails, the entire kubectl output is suppressed as it can echo back secret values. This leaves operators with no signal about which Secret failed.

Replace the silent omission with a message naming the namespace-qualified Secrets being applied, extracted from the manifests kube-applier already holds — not from kubectl's output. Falls back to the existing generic omission message if parsing fails.