### PR TITLE
Guard against applying encrypted strongbox keyring or identity

### DIFF
--- a/run/runner_strongbox_test.go
+++ b/run/runner_strongbox_test.go
@@ -1,8 +1,6 @@
 package run
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,7 +14,7 @@ import (
 func TestVerifyKeyringNotEncrypted(t *testing.T) {
 	makeSecret := func(data map[string][]byte) *corev1.Secret {
 		return &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "strongbox-keyring", Namespace: "example-ns"},
+			ObjectMeta: metav1.ObjectMeta{Name: "strongbox_keyring", Namespace: "example-ns"},
 			Data:       data,
 		}
 	}
@@ -24,45 +22,37 @@ func TestVerifyKeyringNotEncrypted(t *testing.T) {
 	tests := []struct {
 		name    string
 		secret  *corev1.Secret
-		wantErr bool
+		wantErr string
 	}{
 		{
 			name:    "plaintext keyring passes",
 			secret:  makeSecret(map[string][]byte{".strongbox_keyring": []byte("keyid: abc123\n")}),
-			wantErr: false,
+			wantErr: "",
 		},
 		{
 			name:    "strongbox SIV-encrypted keyring is rejected",
 			secret:  makeSecret(map[string][]byte{".strongbox_keyring": []byte("# STRONGBOX ENCRYPTED RESOURCE ; some-ciphertext")}),
-			wantErr: true,
+			wantErr: `strongbox keyring Secret example-ns/strongbox_keyring key ".strongbox_keyring" appears to still be encrypted; check that it has been decrypted before use`,
 		},
 		{
 			name:    "age-armored keyring is rejected",
 			secret:  makeSecret(map[string][]byte{".strongbox_identity": []byte("-----BEGIN AGE ENCRYPTED FILE-----\nsome-ciphertext\n-----END AGE ENCRYPTED FILE-----")}),
-			wantErr: true,
+			wantErr: `strongbox keyring Secret example-ns/strongbox_keyring key ".strongbox_identity" appears to still be encrypted; check that it has been decrypted before use`,
 		},
 		{
 			name:    "empty secret passes",
 			secret:  makeSecret(nil),
-			wantErr: false,
+			wantErr: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Replicate the loop added to SetupStrongboxKeyring.
-			var err error
-			for k, v := range tc.secret.Data {
-				for _, prefix := range encryptedValuePrefixes {
-					if strings.HasPrefix(string(v), prefix) {
-						err = fmt.Errorf("strongbox keyring Secret %s/%s key %q appears to still be encrypted", tc.secret.Namespace, tc.secret.Name, k)
-					}
-				}
-			}
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
+			err := verifyKeyringNotEncrypted(tc.secret)
+			if tc.wantErr == "" {
 				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.wantErr)
 			}
 		})
 	}

--- a/run/runner_strongbox_test.go
+++ b/run/runner_strongbox_test.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,61 @@ import (
 
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 )
+
+func TestVerifyKeyringNotEncrypted(t *testing.T) {
+	makeSecret := func(data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "strongbox-keyring", Namespace: "example-ns"},
+			Data:       data,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		secret  *corev1.Secret
+		wantErr bool
+	}{
+		{
+			name:    "plaintext keyring passes",
+			secret:  makeSecret(map[string][]byte{".strongbox_keyring": []byte("keyid: abc123\n")}),
+			wantErr: false,
+		},
+		{
+			name:    "strongbox SIV-encrypted keyring is rejected",
+			secret:  makeSecret(map[string][]byte{".strongbox_keyring": []byte("# STRONGBOX ENCRYPTED RESOURCE ; some-ciphertext")}),
+			wantErr: true,
+		},
+		{
+			name:    "age-armored keyring is rejected",
+			secret:  makeSecret(map[string][]byte{".strongbox_identity": []byte("-----BEGIN AGE ENCRYPTED FILE-----\nsome-ciphertext\n-----END AGE ENCRYPTED FILE-----")}),
+			wantErr: true,
+		},
+		{
+			name:    "empty secret passes",
+			secret:  makeSecret(nil),
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Replicate the loop added to SetupStrongboxKeyring.
+			var err error
+			for k, v := range tc.secret.Data {
+				for _, prefix := range encryptedValuePrefixes {
+					if strings.HasPrefix(string(v), prefix) {
+						err = fmt.Errorf("strongbox keyring Secret %s/%s key %q appears to still be encrypted", tc.secret.Namespace, tc.secret.Name, k)
+					}
+				}
+			}
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestCheckSecretIsAllowed(t *testing.T) {
 	tests := []struct {

--- a/run/strongbox.go
+++ b/run/strongbox.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
@@ -13,6 +14,14 @@ import (
 )
 
 const cmdWaitDelay = 5 * time.Second
+
+// Known prefixes for strongbox-encrypted content (SIV legacy and age armor).
+// A keyring Secret whose values carry either prefix was not decrypted by the
+// secret-store operator before kube-applier read it.
+var encryptedValuePrefixes = []string{
+	"# STRONGBOX ENCRYPTED RESOURCE ;",
+	"-----BEGIN AGE ENCRYPTED FILE-----",
+}
 
 // strongboxInterface holds functions to configure strongbox for waybill runs
 type StrongboxInterface interface {
@@ -36,6 +45,13 @@ func (sb *strongboxBase) SetupStrongboxKeyring(ctx context.Context, kubeClient *
 	}
 	if err := checkSecretIsAllowed(waybill, secret); err != nil {
 		return err
+	}
+	for k, v := range secret.Data {
+		for _, prefix := range encryptedValuePrefixes {
+			if strings.HasPrefix(string(v), prefix) {
+				return fmt.Errorf("strongbox keyring Secret %s/%s key %q appears to still be encrypted; check that it has been decrypted before use", secret.Namespace, secret.Name, k)
+			}
+		}
 	}
 	keyring, ok1 := secret.Data[".strongbox_keyring"]
 	if ok1 {

--- a/run/strongbox.go
+++ b/run/strongbox.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	kubeapplierv1alpha1 "github.com/utilitywarehouse/kube-applier/apis/kubeapplier/v1alpha1"
 	"github.com/utilitywarehouse/kube-applier/client"
 )
@@ -21,6 +23,21 @@ const cmdWaitDelay = 5 * time.Second
 var encryptedValuePrefixes = []string{
 	"# STRONGBOX ENCRYPTED RESOURCE ;",
 	"-----BEGIN AGE ENCRYPTED FILE-----",
+}
+
+// verifyKeyringNotEncrypted returns an error if any value in the keyring
+// Secret's Data still carries a strongbox/age ciphertext prefix, meaning
+// the secret-store operator did not decrypt it before kube-applier read it.
+// Best-effort heuristic: it only catches known ciphertext markers.
+func verifyKeyringNotEncrypted(secret *corev1.Secret) error {
+	for k, v := range secret.Data {
+		for _, prefix := range encryptedValuePrefixes {
+			if strings.HasPrefix(string(v), prefix) {
+				return fmt.Errorf("strongbox keyring Secret %s/%s key %q appears to still be encrypted; check that it has been decrypted before use", secret.Namespace, secret.Name, k)
+			}
+		}
+	}
+	return nil
 }
 
 // strongboxInterface holds functions to configure strongbox for waybill runs
@@ -46,12 +63,8 @@ func (sb *strongboxBase) SetupStrongboxKeyring(ctx context.Context, kubeClient *
 	if err := checkSecretIsAllowed(waybill, secret); err != nil {
 		return err
 	}
-	for k, v := range secret.Data {
-		for _, prefix := range encryptedValuePrefixes {
-			if strings.HasPrefix(string(v), prefix) {
-				return fmt.Errorf("strongbox keyring Secret %s/%s key %q appears to still be encrypted; check that it has been decrypted before use", secret.Namespace, secret.Name, k)
-			}
-		}
+	if err := verifyKeyringNotEncrypted(secret); err != nil {
+		return err
 	}
 	keyring, ok1 := secret.Data[".strongbox_keyring"]
 	if ok1 {


### PR DESCRIPTION
Guard against applying a strongbox keyring or identity Secret
whose Data still carries ciphertext, meaning the secret-store
operator did not decrypt it before kube-applier read it.
Returns an error naming the offending key before any keyring
file is written to disk.

- Reject SIV-encrypted ("# STRONGBOX ENCRYPTED RESOURCE ;") and
  age-armored ("-----BEGIN AGE ENCRYPTED FILE-----") values
- Extract verifyKeyringNotEncrypted helper called from
  SetupStrongboxKeyring, returning on first match
- Test the helper directly with exact error-message assertions

Split out of #321, which surfaces Secret names on failed Secret
applies.