### PR TITLE
Default to shallow git clone and force-run on diff failure

### DIFF
--- a/git/repository.go
+++ b/git/repository.go
@@ -309,7 +309,7 @@ func (r *Repository) gitCleanup(ctx context.Context) error {
 
 	gitRepoPath := filepath.Join(r.path, ".git")
 	// GC clone
-	if _, err := r.runGitCommand(ctx, nil, r.path, "gc", "--prune=all"); err != nil {
+	if _, err := r.runGitCommand(ctx, nil, r.path, "gc"); err != nil {
 		commitGraphLock := filepath.Join(gitRepoPath, "objects/info/commit-graph.lock")
 		if strings.Contains(err.Error(), fmt.Sprintf("Unable to create '%s': File exists.", commitGraphLock)) {
 			if e := os.Remove(commitGraphLock); e != nil {

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	fOidcIssuer          = flag.String("oidc-issuer", getStringEnv("OIDC_ISSUER", ""), "OIDC issuer URL of the authentication server")
 	fPruneBlacklist      = flag.String("prune-blacklist", getStringEnv("PRUNE_BLACKLIST", ""), "Comma-separated list of resources to add to the global prune blacklist, in the <group>/<version>/<kind> format")
 	fRepoBranch          = flag.String("repo-branch", getStringEnv("REPO_BRANCH", "master"), "Branch of the git repository to use")
-	fRepoDepth           = flag.Int("repo-depth", getIntEnv("REPO_DEPTH", 0), "Depth of the git repository to fetch. Use zero to ignore")
+	fRepoDepth           = flag.Int("repo-depth", getIntEnv("REPO_DEPTH", 1), "Depth of the git repository to fetch. Use zero to ignore")
 	fRepoDest            = flag.String("repo-dest", getStringEnv("REPO_DEST", "/src"), "Path under which the the git repository is fetched")
 	fRepoPath            = flag.String("repo-path", getStringEnv("REPO_PATH", ""), "Path relative to the repository root that kube-applier operates in")
 	fRepoRemote          = flag.String("repo-remote", getStringEnv("REPO_REMOTE", ""), "Remote URL of the git repository that kube-applier uses as a source")

--- a/run/scheduler.go
+++ b/run/scheduler.go
@@ -236,7 +236,8 @@ func (s *Scheduler) waybillsWithGitChanges() []*kubeapplierv1alpha1.Waybill {
 		wbId := fmt.Sprintf("%s/%s", waybills[i].Namespace, waybills[i].Name)
 		changed, err := s.Repository.HasChangesForPath(ctx, filepath.Join(s.RepoPath, path), sinceHash)
 		if err != nil {
-			log.Logger("scheduler").Warn("Could not check path for changes, skipping polling run", "waybill", wbId, "path", path, "since", sinceHash, "error", err)
+			log.Logger("scheduler").Warn("Could not check path for changes, forcing polling run", "waybill", wbId, "path", path, "since", sinceHash, "error", err)
+			result = append(result, waybills[i])
 			continue
 		}
 		if changed {

--- a/run/scheduler_git_test.go
+++ b/run/scheduler_git_test.go
@@ -170,6 +170,27 @@ func TestWaybillsWithGitChanges(t *testing.T) {
 		assert.Equal(t, "empty-commit", result[0].Namespace)
 	})
 
+	t.Run("returns Waybill when HasChangesForPath fails (pruned commit)", func(t *testing.T) {
+		s := makeScheduler(map[string]*kubeapplierv1alpha1.Waybill{
+			"pruned-commit": {
+				ObjectMeta: metav1.ObjectMeta{Namespace: "pruned-commit"},
+				Spec: kubeapplierv1alpha1.WaybillSpec{
+					RepositoryPath: "app-a",
+				},
+				Status: kubeapplierv1alpha1.WaybillStatus{
+					LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+						Commit:   "nonexistentdeadbeef",
+						Started:  now,
+						Finished: now,
+					},
+				},
+			},
+		}, "")
+		result := s.waybillsWithGitChanges()
+		require.Len(t, result, 1)
+		assert.Equal(t, "pruned-commit", result[0].Namespace)
+	})
+
 	t.Run("returns only changed Waybills from a mixed set", func(t *testing.T) {
 		s := makeScheduler(map[string]*kubeapplierv1alpha1.Waybill{
 			"no-last-run": {


### PR DESCRIPTION
A full-history clone of a large manifests repo can take long enough to exceed REPO_TIMEOUT and crash-loop the pod. A depth-1 clone is dramatically faster and smaller with no loss of functionality for kube-applier's working-tree-only workflow.

- Default REPO_DEPTH from 0 (full history) to 1 (shallow). The --depth plumbing already existed; only the default changes. REPO_DEPTH=0 still opts out.
- Drop --prune=all from the daily git gc, relying on git's default 2-week prune window so orphaned shallow tips survive long enough for diff-based change detection.
- Force a polling run when HasChangesForPath errors instead of skipping the waybill. Applies are idempotent so re-applying is safer than silently skipping.
- Add a test case asserting the force-run-on-failure behavior with a nonexistent commit hash.