### PR TITLE
Add per-namespace status pages

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -9,11 +9,19 @@ $(document).ready(function() {
             forceRun($(this).data('namespace'))
         });
     });
+
+    // Swap +/- glyph on collapse toggle buttons.
+    $('.panel-collapse').on('shown.bs.collapse', function () {
+        $('button.ns-toggle[data-target="#' + this.id + '"]').text('-');
+    });
+    $('.panel-collapse').on('hidden.bs.collapse', function () {
+        $('button.ns-toggle[data-target="#' + this.id + '"]').text('+');
+    });
 });
 
 // Send an XHR request to the server to force a run.
 function forceRun(namespace) {
-    url =  window.location.href + 'api/v1/forceRun';
+    url =  '/api/v1/forceRun';
     $.ajax({
         type: 'POST',
         url: url,

--- a/static/stylesheets/main.css
+++ b/static/stylesheets/main.css
@@ -24,3 +24,8 @@ pre.commit {
 .force-button-group {
 	margin-bottom: 5px;
 }
+
+.ns-toggle {
+	margin-left: 5px;
+	padding: 1px 6px;
+}

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,4 +1,4 @@
-{{define "index"}}
+{{define "pageHeader"}}
 <!doctype html>
 <html>
 <head>
@@ -12,34 +12,36 @@
 </head>
 <body>
     <h1 class="text-center">kube-applier</h1>
-    {{ if . }}
+{{end}}
+
+{{define "index"}}{{template "pageHeader" .}}    {{ if .Namespaces }}
         <div class="row">
             <div class="col-md-4"></div>
             <div id="force-alert-container" class="col-md-4"></div>
         </div>
     
-        {{ if (filter . "pending").Namespaces }}
-            {{template "section" (filter . "pending")}}
+        {{ if (filter .Namespaces "pending").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "pending"))}}
         {{ end }}
 
-        {{ if (filter . "auto-apply-disabled").Namespaces }}
-            {{template "section" (filter . "auto-apply-disabled")}}
+        {{ if (filter .Namespaces "auto-apply-disabled").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "auto-apply-disabled"))}}
         {{ end }}
 
-        {{ if (filter . "dry-run").Namespaces }}
-            {{template "section" (filter . "dry-run")}}
+        {{ if (filter .Namespaces "dry-run").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "dry-run"))}}
         {{ end }}
         
-        {{ if (filter . "failure").Namespaces }}
-            {{template "section" (filter . "failure")}}
+        {{ if (filter .Namespaces "failure").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "failure"))}}
         {{ end }}
 
-        {{ if (filter . "warning").Namespaces }}
-            {{template "section" (filter . "warning")}}
+        {{ if (filter .Namespaces "warning").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "warning"))}}
         {{ end }}
 
-        {{ if (filter . "success").Namespaces }}
-            {{template "section" (filter . "success")}}
+        {{ if (filter .Namespaces "success").Namespaces }}
+            {{template "section" (withSelect .SelectedNamespace (filter .Namespaces "success"))}}
         {{ end }}
 
     {{ else }}
@@ -66,8 +68,6 @@
                                 Auto Apply Disabled Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.FilteredBy "dry-run"}}
                                 Dry Run Only Namespaces: {{ len .Namespaces }} / {{ .Total }}
-                            {{else if eq $.FilteredBy "pending"}}
-                                Pending Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.FilteredBy "failure"}}
                                 Failed Namespaces: {{ len .Namespaces }} / {{ .Total }}
                             {{else if eq $.FilteredBy "warning"}}
@@ -80,7 +80,7 @@
                 </div>
                 <div id="{{$.FilteredBy}}" class="panel-group collapse in">
                     {{ range $wb :=  .Namespaces }}
-                        {{template "namespace" $wb}}
+                        {{template "namespace" (nsWithSelect $.SelectedNamespace $wb)}}
                     {{ end }}
                 </div>
             </div>
@@ -94,11 +94,12 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#{{.Waybill.Namespace}}">{{ .Waybill.Namespace }} {{ status .Waybill }}</a>
+          <a href="/ns/{{.Waybill.Namespace}}">{{ .Waybill.Namespace }} {{ status .Waybill }}</a>{{if .Waybill.Status.LastRun }}
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#{{.Waybill.Namespace}}" aria-expanded="{{if eq .Waybill.Namespace .SelectedNamespace}}true{{else}}false{{end}}">{{if eq .Waybill.Namespace .SelectedNamespace}}-{{else}}+{{end}}</button>{{end}}
       </div>
   </div>
   {{if .Waybill.Status.LastRun }}
-  <div id="{{.Waybill.Namespace}}" class="panel-collapse collapse">
+  <div id="{{.Waybill.Namespace}}" class="panel-collapse collapse{{if eq .Waybill.Namespace .SelectedNamespace}} in{{end}}">
       <ul class="list-group">
           <li class="list-group-item">
               <div class="row">
@@ -158,4 +159,24 @@
   </div>
   {{ end }}
 </div>
+{{ end }}
+
+{{define "namespacePage"}}{{template "pageHeader" .}}    <div class="row">
+        <div class="col-md-2"></div>
+        <div class="col-md-8"><a href="/">Back to all namespaces</a></div>
+    </div>
+    <div class="row">
+        <div class="col-md-4"></div>
+        <div id="force-alert-container" class="col-md-4"></div>
+    </div>
+    {{ range $wb := .Namespaces }}
+    <div class="row">
+        <div class="col-md-2"></div>
+        <div class="col-md-8">
+            {{template "namespace" (nsWithSelect $.SelectedNamespace $wb)}}
+        </div>
+    </div>
+    {{ end }}
+</body>
+</html>
 {{ end }}

--- a/testdata/web/testStatusPage.html
+++ b/testdata/web/testStatusPage.html
@@ -39,7 +39,7 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#foo">foo </a>
+          <a href="/ns/foo">foo </a>
       </div>
   </div>
   
@@ -76,7 +76,7 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#bar">bar (auto-apply disabled)</a>
+          <a href="/ns/bar">bar (auto-apply disabled)</a>
       </div>
   </div>
   
@@ -113,7 +113,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#biz">biz (dry-run)</a>
+          <a href="/ns/biz">biz (dry-run)</a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#biz" aria-expanded="false">+</button>
       </div>
   </div>
   
@@ -203,7 +204,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#zot">zot </a>
+          <a href="/ns/zot">zot </a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#zot" aria-expanded="false">+</button>
       </div>
   </div>
   
@@ -264,7 +266,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#zoo">zoo </a>
+          <a href="/ns/zoo">zoo </a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#zoo" aria-expanded="false">+</button>
       </div>
   </div>
   
@@ -374,7 +377,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#fuz">fuz </a>
+          <a href="/ns/fuz">fuz </a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#fuz" aria-expanded="false">+</button>
       </div>
   </div>
   
@@ -478,7 +482,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#buz">buz </a>
+          <a href="/ns/buz">buz </a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#buz" aria-expanded="false">+</button>
       </div>
   </div>
   
@@ -548,7 +553,8 @@
 <div class="panel">
   <div class="panel-heading">
       <div class="panel-title">
-          <a data-toggle="collapse" href="#eng">eng </a>
+          <a href="/ns/eng">eng </a>
+          <button type="button" class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#eng" aria-expanded="false">+</button>
       </div>
   </div>
   

--- a/webserver/result.go
+++ b/webserver/result.go
@@ -57,6 +57,28 @@ type Filtered struct {
 	Namespaces []Namespace
 }
 
+// pageData is the root data passed to the status page template.
+type pageData struct {
+	Namespaces        []Namespace
+	SelectedNamespace string
+}
+
+// sectionData wraps Filtered so the selected namespace name flows into the
+// section sub-template. Filtered fields are promoted via embedding, so
+// existing template accesses (.FilteredBy, .Total, .Namespaces) still work.
+type sectionData struct {
+	Filtered
+	SelectedNamespace string
+}
+
+// namespaceData wraps Namespace so the selected namespace name flows into the
+// namespace sub-template. Namespace fields are promoted via embedding, so
+// existing accesses (.Waybill, .Events, .DiffURLFormat) still work.
+type namespaceData struct {
+	Namespace
+	SelectedNamespace string
+}
+
 func filter(Namespaces []Namespace, filteredBy string) Filtered {
 	filtered := Filtered{
 		FilteredBy: filteredBy,
@@ -101,6 +123,20 @@ func filter(Namespaces []Namespace, filteredBy string) Filtered {
 		}
 	}
 	return filtered
+}
+
+// withSelect builds a sectionData from a selected namespace name and a Filtered
+// result, so the section template can pass the selected namespace down to each
+// namespace it renders.
+func withSelect(selected string, f Filtered) sectionData {
+	return sectionData{Filtered: f, SelectedNamespace: selected}
+}
+
+// nsWithSelect builds a namespaceData from a selected namespace name and a
+// Namespace, so the namespace template can decide whether to render its
+// collapsible panel expanded.
+func nsWithSelect(selected string, n Namespace) namespaceData {
+	return namespaceData{Namespace: n, SelectedNamespace: selected}
 }
 
 func isAutoApplyEnabled(ns Namespace) bool {

--- a/webserver/template.go
+++ b/webserver/template.go
@@ -21,6 +21,8 @@ func createTemplate(templatePath string) (*template.Template, error) {
 			"status":          status,
 			"splitByNewline":  splitByNewline,
 			"getOutputClass":  getOutputClass,
+			"withSelect":      withSelect,
+			"nsWithSelect":    nsWithSelect,
 		}).
 		ParseFiles(templatePath)
 	if err != nil {

--- a/webserver/template_test.go
+++ b/webserver/template_test.go
@@ -241,7 +241,7 @@ Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21+, unavail
 	}
 
 	rendered := &bytes.Buffer{}
-	err = templt.ExecuteTemplate(rendered, "index", result)
+	err = templt.ExecuteTemplate(rendered, "index", pageData{Namespaces: result})
 	if err != nil {
 		t.Errorf("error executing template: %v\n", err)
 		return
@@ -256,5 +256,59 @@ Warning: discovery.k8s.io/v1beta1 EndpointSlice is deprecated in v1.21+, unavail
 
 	if diff := cmp.Diff(string(want), rendered.String(), removeSpaceEmptyLine); diff != "" {
 		t.Errorf("ExecuteTemplate mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func Test_ExecuteTemplate_NamespacePage(t *testing.T) {
+	wbList := []kubeapplierv1alpha1.Waybill{
+		{
+			TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "main",
+				Namespace: "test-ns",
+			},
+			Spec: kubeapplierv1alpha1.WaybillSpec{},
+			Status: kubeapplierv1alpha1.WaybillStatus{
+				LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+					Started:  metav1.Time{Time: fixedTime.Add(-time.Minute)},
+					Finished: metav1.Time{Time: fixedTime},
+					Type:     "Test run",
+				},
+			},
+		},
+	}
+
+	result := GetNamespaces(wbList, nil, diffURL)
+
+	templt, err := createTemplate("../templates/status.html")
+	if err != nil {
+		t.Errorf("error parsing template: %v\n", err)
+		return
+	}
+
+	rendered := &bytes.Buffer{}
+	err = templt.ExecuteTemplate(rendered, "namespacePage", pageData{
+		Namespaces:        result,
+		SelectedNamespace: "test-ns",
+	})
+	if err != nil {
+		t.Errorf("error executing template: %v\n", err)
+		return
+	}
+	output := rendered.String()
+
+	// Should contain the back link.
+	if !strings.Contains(output, "Back to all namespaces") {
+		t.Errorf("namespace page should contain back link")
+	}
+
+	// Panel should be expanded because SelectedNamespace matches.
+	if !strings.Contains(output, `id="test-ns" class="panel-collapse collapse in"`) {
+		t.Errorf("namespace panel should be expanded on the namespace page")
+	}
+
+	// Toggle button should show '-' (expanded) on the single-ns page.
+	if !strings.Contains(output, `class="btn btn-default btn-xs ns-toggle" data-toggle="collapse" data-target="#test-ns" aria-expanded="true">-</button>`) {
+		t.Errorf("namespace page should have the toggle button with '-' glyph for the expanded namespace")
 	}
 }

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -88,8 +88,49 @@ func (s *StatusPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	result := GetNamespaces(waybills, events, s.DiffURLFormat)
 
+	selected := mux.Vars(r)["namespace"]
+
+	if selected == "" {
+		// Main page: render full list of namespaces.
+		pageData := pageData{
+			Namespaces:        result,
+			SelectedNamespace: "",
+		}
+
+		rendered := &bytes.Buffer{}
+		if err := s.Template.ExecuteTemplate(rendered, "index", pageData); err != nil {
+			http.Error(w, "Error: Unable to render HTML template", http.StatusInternalServerError)
+			log.Logger("webserver").Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String(), "err", err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := rendered.WriteTo(w); err != nil {
+			log.Logger("webserver").Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String(), "err", err)
+		}
+		log.Logger("webserver").Info("Request completed successfully", "time", s.Clock.Now().String())
+		return
+	}
+
+	// Single namespace page: find the requested namespace and render it alone.
+	var found *Namespace
+	for i := range result {
+		if result[i].Waybill.Namespace == selected {
+			found = &result[i]
+			break
+		}
+	}
+	if found == nil {
+		http.Error(w, "namespace not found", http.StatusNotFound)
+		return
+	}
+
+	pageData := pageData{
+		Namespaces:        []Namespace{*found},
+		SelectedNamespace: selected,
+	}
+
 	rendered := &bytes.Buffer{}
-	if err := s.Template.ExecuteTemplate(rendered, "index", result); err != nil {
+	if err := s.Template.ExecuteTemplate(rendered, "namespacePage", pageData); err != nil {
 		http.Error(w, "Error: Unable to render HTML template", http.StatusInternalServerError)
 		log.Logger("webserver").Error("Request failed", "error", http.StatusInternalServerError, "time", s.Clock.Now().String(), "err", err)
 		return
@@ -243,6 +284,7 @@ func (ws *WebServer) Start() error {
 	}
 	m.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
 	m.PathPrefix("/api/v1/forceRun").Handler(forceRunHandler)
+	m.HandleFunc("/ns/{namespace}", statusPageHandler.ServeHTTP)
 	m.PathPrefix("/").Handler(statusPageHandler)
 
 	ws.server = &http.Server{

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -66,12 +66,26 @@ var _ = Describe("WebServer", func() {
 					Name:      "main",
 					Namespace: "foo",
 				},
+				Status: kubeapplierv1alpha1.WaybillStatus{
+					LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+						Started:  metav1.Time{Time: time.Now()},
+						Finished: metav1.Time{Time: time.Now()},
+						Type:     "Test run",
+					},
+				},
 			},
 			{
 				TypeMeta: metav1.TypeMeta{APIVersion: "kube-applier.io/v1alpha1", Kind: "Waybill"},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "main",
 					Namespace: "bar",
+				},
+				Status: kubeapplierv1alpha1.WaybillStatus{
+					LastRun: &kubeapplierv1alpha1.WaybillStatusRun{
+						Started:  metav1.Time{Time: time.Now()},
+						Finished: metav1.Time{Time: time.Now()},
+						Type:     "Test run",
+					},
 				},
 			},
 		}
@@ -138,6 +152,47 @@ var _ = Describe("WebServer", func() {
 			Expect(err).To(BeNil())
 			Expect(res.StatusCode).To(Equal(http.StatusOK))
 			Expect(body).ToNot(BeEmpty())
+
+			testWebServer.Shutdown()
+			close(testRunQueue)
+			Expect(testWebServerRequests()).To(Equal([]run.Request{}))
+		})
+
+		It("Should respond on the /ns/<namespace> route", func() {
+			testEnsureWaybills(wbList)
+
+			var fooBody string
+			Eventually(
+				func() error {
+					res, err := http.Get(fmt.Sprintf("http://localhost:%d/ns/foo", testWebServer.ListenPort))
+					if err != nil {
+						return err
+					}
+					defer res.Body.Close()
+					if res.StatusCode != http.StatusOK {
+						return fmt.Errorf("status %d", res.StatusCode)
+					}
+					b, err := io.ReadAll(res.Body)
+					if err != nil {
+						return err
+					}
+					fooBody = string(b)
+					return nil
+				},
+				time.Second*15,
+				time.Second,
+			).Should(BeNil())
+
+			// Single-namespace page shows only the matching namespace.
+			Expect(fooBody).To(ContainSubstring("Back to all namespaces"))
+			Expect(fooBody).To(ContainSubstring("foo"))
+			Expect(fooBody).ToNot(ContainSubstring("bar"))
+
+			// Unknown namespace returns 404.
+			res, err := http.Get(fmt.Sprintf("http://localhost:%d/ns/nonexistent", testWebServer.ListenPort))
+			Expect(err).To(BeNil())
+			defer res.Body.Close()
+			Expect(res.StatusCode).To(Equal(http.StatusNotFound))
 
 			testWebServer.Shutdown()
 			close(testRunQueue)


### PR DESCRIPTION
Each namespace name now links to a dedicated /ns/<namespace> page showing only that namespace's panel, expanded, with a breadcrumb back to the full list. Panel collapse moves to an explicit +/- toggle button so the title can act as a link.

Root template data is refactored from a bare []Namespace into a pageData struct carrying SelectedNamespace, threaded through the sub-templates via withSelect/nsWithSelect helpers.

Also fixes forceRun() in main.js, which concatenated onto window.location.href and produced a garbage URL on /ns/<ns> pages.